### PR TITLE
Adding timestamp from block header to confirmed transactions status.

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -650,10 +650,11 @@ impl Query {
             .chain_err(|| "invalid block height for tx")?;
 
         // the block at confirmation height is not the one containing the tx, must've reorged!
+
         if header.hash() != &blockhash {
             Ok(TransactionStatus::unconfirmed())
         } else {
-            Ok(TransactionStatus::confirmed(&header))
+            Ok(TransactionStatus::confirmed(&header, header.confirmed_at()))
         }
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -654,7 +654,7 @@ impl Query {
         if header.hash() != &blockhash {
             Ok(TransactionStatus::unconfirmed())
         } else {
-            Ok(TransactionStatus::confirmed(&header, header.confirmed_at()))
+            Ok(TransactionStatus::confirmed(&header, header.timestamp()))
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -127,7 +127,7 @@ impl HeaderEntry {
         self.height
     }
     
-    pub fn confirmed_at(&self) -> u32 {
+    pub fn timestamp(&self) -> u32 {
         self.header.time
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -33,6 +33,7 @@ pub struct TransactionStatus {
     pub confirmed: bool,
     pub block_height: Option<usize>,
     pub block_hash: Option<Sha256dHash>,
+    pub confirmed_at: Option<u32>,
 }
 
 impl TransactionStatus {
@@ -41,15 +42,18 @@ impl TransactionStatus {
             confirmed: false,
             block_height: None,
             block_hash: None,
+            confirmed_at: None,
         }
     }
-    pub fn confirmed(header: &HeaderEntry) -> Self {
+    pub fn confirmed(header: &HeaderEntry, timestamp: u32) -> Self {
         TransactionStatus {
             confirmed: true,
             block_height: Some(header.height()),
             block_hash: Some(header.hash().clone()),
+            confirmed_at: Some(timestamp),
         }
     }
+    // pub fn get_header
 }
 
 #[derive(Serialize, Deserialize)]
@@ -121,6 +125,10 @@ impl HeaderEntry {
 
     pub fn height(&self) -> usize {
         self.height
+    }
+    
+    pub fn confirmed_at(&self) -> u32 {
+        self.header.time
     }
 }
 


### PR DESCRIPTION
In response to requests made on the [esplora repository]( https://github.com/Blockstream/esplora/issues/10)
This solution requires extra query and doesn't affect existing index structure.

