### PR TITLE
[DONOTMERGE] add signet support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ arraydeque = "0.4"
 arrayref = "0.3"
 base64 = "0.10"
 bincode = "1.0"
-bitcoin-bech32 = "0.9.0"
+bitcoin-bech32 = "0.10.0"
 chan = "0.1"
 chan-signal = "0.3"
 clap = "2.31"
@@ -53,7 +53,8 @@ tiny_http = "0.6"
 url = "1.0"
 
 [dependencies.bitcoin]
-version = "0.18"
+git = "http://github.com/kallewoof/rust-bitcoin"
+branch = "2019-07-signet"
 features = ["serde"]
 
 [dependencies.bitcoin_hashes]

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -23,6 +23,7 @@ pub use confidential::Value;
 pub enum Network {
     Bitcoin,
     Testnet,
+    Signet,
     Regtest,
 
     #[cfg(feature = "liquid")]
@@ -41,6 +42,7 @@ impl Network {
         match self {
             Network::Bitcoin => 0xD9B4BEF9,
             Network::Testnet => 0x0709110B,
+            Network::Signet  => 0x6A70C7F0,
             Network::Regtest => 0xDAB5BFFA,
 
             #[cfg(feature = "liquid")]
@@ -65,6 +67,7 @@ impl Network {
         return vec![
             "mainnet".to_string(),
             "testnet".to_string(),
+            "signet".to_string(),
             "regtest".to_string(),
         ];
 
@@ -72,6 +75,7 @@ impl Network {
         return vec![
             "mainnet".to_string(),
             "testnet".to_string(),
+            "signet".to_string(),
             "regtest".to_string(),
             "liquid".to_string(),
             "liquidregtest".to_string(),
@@ -84,6 +88,7 @@ impl From<&str> for Network {
         match network_name {
             "mainnet" => Network::Bitcoin,
             "testnet" => Network::Testnet,
+            "signet" => Network::Signet,
             "regtest" => Network::Regtest,
 
             #[cfg(feature = "liquid")]
@@ -101,6 +106,7 @@ impl From<&Network> for BNetwork {
         match network {
             Network::Bitcoin => BNetwork::Bitcoin,
             Network::Testnet => BNetwork::Testnet,
+            Network::Signet => BNetwork::Signet,
             Network::Regtest => BNetwork::Regtest,
 
             #[cfg(feature = "liquid")]
@@ -116,6 +122,7 @@ impl From<&Network> for B32Network {
         match network {
             Network::Bitcoin => B32Network::Bitcoin,
             Network::Testnet => B32Network::Testnet,
+            Network::Signet => B32Network::Signet,
             Network::Regtest => B32Network::Regtest,
             #[cfg(feature = "liquid")]
             Network::Liquid => B32Network::Bitcoin, // @FIXME
@@ -138,6 +145,7 @@ impl From<&BNetwork> for Network {
             #[cfg(feature = "liquid")]
             BNetwork::Regtest => Network::LiquidRegtest, // @FIXME
             BNetwork::Testnet => Network::Testnet, // @FIXME
+            BNetwork::Signet => Network::Signet, // @FIXME
         }
     }
 }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -42,7 +42,7 @@ impl Network {
         match self {
             Network::Bitcoin => 0xD9B4BEF9,
             Network::Testnet => 0x0709110B,
-            Network::Signet  => 0x6A70C7F0,
+            Network::Signet  => 0x7EC653A5,
             Network::Regtest => 0xDAB5BFFA,
 
             #[cfg(feature = "liquid")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,6 +185,7 @@ impl Config {
             Network::Bitcoin => 8332,
             Network::Testnet => 18332,
             Network::Regtest => 18443,
+            Network::Signet  => 38332,
 
             #[cfg(feature = "liquid")]
             Network::Liquid => 7041,
@@ -195,6 +196,7 @@ impl Config {
             Network::Bitcoin => 50001,
             Network::Testnet => 60001,
             Network::Regtest => 60401,
+            Network::Signet  => 60801,
 
             #[cfg(feature = "liquid")]
             Network::Liquid => 51000,
@@ -205,6 +207,7 @@ impl Config {
             Network::Bitcoin => 3000,
             Network::Testnet => 3001,
             Network::Regtest => 3002,
+            Network::Signet  => 3003,
 
             #[cfg(feature = "liquid")]
             Network::Liquid => 3000,
@@ -215,6 +218,7 @@ impl Config {
             Network::Bitcoin => 4224,
             Network::Testnet => 14224,
             Network::Regtest => 24224,
+            Network::Signet  => 18224,
 
             #[cfg(feature = "liquid")]
             Network::Liquid => 34224,
@@ -254,6 +258,7 @@ impl Config {
         match network_type {
             Network::Bitcoin => (),
             Network::Testnet => daemon_dir.push("testnet3"),
+            Network::Signet  => daemon_dir.push("signet"),
             Network::Regtest => daemon_dir.push("regtest"),
 
             #[cfg(feature = "liquid")]


### PR DESCRIPTION
This PR adds the "signet" network type to the list of networks.

Note that this cannot be merged yet, due to chicken-egg issue with rust-bitcoin related crates (this requires signet enabled rust-bitcoin so it currently points at my repository). Posting it for review/consideration only.

See also:
* https://github.com/rust-bitcoin/constants/pull/8
* https://github.com/rust-bitcoin/rust-bech32-bitcoin/pull/24 (merged)
* https://github.com/rust-bitcoin/rust-bitcoin/pull/291
