### PR TITLE
Fix test_db_iterator

### DIFF
--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -217,13 +217,16 @@ impl DB {
 #[cfg(test)]
 mod tests {
 
+    use crate::config::Config;
     use crate::new_index::db::{DBRow, DB};
+    use std::sync::Arc;
     use tempfile;
 
     #[test]
     fn test_db_iterator() {
+        let config = Arc::new(Config::from_args());
         let dir = tempfile::tempdir().unwrap();
-        let db = DB::open(dir.path());
+        let db = DB::open(dir.path(), &config);
         let rows = vec![
             DBRow {
                 key: b"X11".to_vec(),


### PR DESCRIPTION
`cargo test`
Below is the result.

```
error[E0061]: this function takes 2 parameters but 1 parameter was supplied
   --> src/new_index/db.rs:226:18
    |
84  |     pub fn open(path: &Path, config: &Config) -> DB {
    |     ----------------------------------------------- defined here
...
226 |         let db = DB::open(dir.path());
    |                  ^^^^^^^^^^^^^^^^^^^^ expected 2 parameters

error: aborting due to previous error

For more information about this error, try `rustc --explain E0061`.
error: could not compile `electrs`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```