### PR TITLE
Add a 'blocks_dir' option analogous to bitcoind's '-blocksdir'

### DIFF
--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -47,6 +47,7 @@ fn run_server(config: Arc<Config>) -> Result<()> {
 
     let daemon = Arc::new(Daemon::new(
         &config.daemon_dir,
+        &config.blocks_dir,
         config.daemon_rpc_addr,
         config.cookie_getter(),
         config.network_type,

--- a/src/bin/tx-fingerprint-stats.rs
+++ b/src/bin/tx-fingerprint-stats.rs
@@ -31,6 +31,7 @@ fn main() {
     let daemon = Arc::new(
         Daemon::new(
             &config.daemon_dir,
+            &config.blocks_dir,
             config.daemon_rpc_addr,
             config.cookie_getter(),
             config.network_type,

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub network_type: Network,
     pub db_path: PathBuf,
     pub daemon_dir: PathBuf,
+    pub blocks_dir: PathBuf,
     pub daemon_rpc_addr: SocketAddr,
     pub cookie: Option<String>,
     pub electrum_rpc_addr: SocketAddr,
@@ -87,6 +88,12 @@ impl Config {
                 Arg::with_name("daemon_dir")
                     .long("daemon-dir")
                     .help("Data directory of Bitcoind (default: ~/.bitcoin/)")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name("blocks_dir")
+                    .long("blocks-dir")
+                    .help("Analogous to bitcoind's -blocksdir option, this specifies the directory containing the raw blocks files (blk*.dat) (default: ~/.bitcoin/blocks/)")
                     .takes_value(true),
             )
             .arg(
@@ -302,6 +309,10 @@ impl Config {
             #[cfg(feature = "liquid")]
             Network::LiquidRegtest => daemon_dir.push("liquidregtest"),
         }
+        let blocks_dir = m
+            .value_of("blocks_dir")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| daemon_dir.join("blocks"));
         let cookie = m.value_of("cookie").map(|s| s.to_owned());
 
         let electrum_banner = m.value_of("electrum_banner").map_or_else(
@@ -327,6 +338,7 @@ impl Config {
             network_type,
             db_path,
             daemon_dir,
+            blocks_dir,
             daemon_rpc_addr,
             cookie,
             utxos_limit: value_t_or_exit!(m, "utxos_limit", usize),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -261,6 +261,7 @@ impl Counter {
 
 pub struct Daemon {
     daemon_dir: PathBuf,
+    blocks_dir: PathBuf,
     network: Network,
     conn: Mutex<Connection>,
     message_id: Counter, // for monotonic JSONRPC 'id'
@@ -274,6 +275,7 @@ pub struct Daemon {
 impl Daemon {
     pub fn new(
         daemon_dir: &PathBuf,
+        blocks_dir: &PathBuf,
         daemon_rpc_addr: SocketAddr,
         cookie_getter: Arc<dyn CookieGetter>,
         network: Network,
@@ -282,6 +284,7 @@ impl Daemon {
     ) -> Result<Daemon> {
         let daemon = Daemon {
             daemon_dir: daemon_dir.clone(),
+            blocks_dir: blocks_dir.clone(),
             network,
             conn: Mutex::new(Connection::new(
                 daemon_rpc_addr,
@@ -333,6 +336,7 @@ impl Daemon {
     pub fn reconnect(&self) -> Result<Daemon> {
         Ok(Daemon {
             daemon_dir: self.daemon_dir.clone(),
+            blocks_dir: self.blocks_dir.clone(),
             network: self.network,
             conn: Mutex::new(self.conn.lock().unwrap().reconnect()?),
             message_id: Counter::new(),
@@ -343,9 +347,7 @@ impl Daemon {
     }
 
     pub fn list_blk_files(&self) -> Result<Vec<PathBuf>> {
-        let mut path = self.daemon_dir.clone();
-        path.push("blocks");
-        path.push("blk*.dat");
+        let path = self.blocks_dir.join("blk*.dat");
         debug!("listing block files at {:?}", path);
         let mut paths: Vec<PathBuf> = glob::glob(path.to_str().unwrap())
             .chain_err(|| "failed to list blk*.dat files")?


### PR DESCRIPTION
I used the quite convenient `-blocksdir` option (https://github.com/bitcoin/bitcoin/pull/12653) on my `bitcoind`, but had to fall back to symlinking the `blocks/` to be able to use Electrs with `blk`s on a different disk.

This makes Electrs aware that the `blk`s might not always be in `<config_dir>/blocks/`.

*(This is the adapted version of https://github.com/romanz/electrs/pull/269)*