### PR TITLE
Add index-unspendables CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ In addition to electrs's original configuration options, a few new options are a
 - `--lightmode` - enable light mode (see above)
 - `--cors <origins>` - origins allowed to make cross-site request (optional, defaults to none).
 - `--address-search` - enables the by-prefix address search index.
+- `--index-unspendables` - enables indexing of provably unspendable outputs.
 - `--utxos-limit <num>` - maximum number of utxos to return per address.
 - `--electrum-txs-limit <num>` - maximum number of txs to return per address in the electrum server (does not apply for the http api).
 - `--electrum-banner <text>` - welcome banner text for electrum server.

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -43,7 +43,7 @@ When the indexer is synced up to the tip of the chain, the hash of the tip is sa
 
 ### `history`
 
-Each funding output (except for provably unspendable ones) results in the following new rows (`H` is for history, `F` is for funding):
+Each funding output (except for provably unspendable ones when `--index-unspendables` is not enabled) results in the following new rows (`H` is for history, `F` is for funding):
 
  * `"H{funding-scripthash}{funding-height}F{funding-txid:vout}{value}" → ""`
  * `"a{funding-address-str}" → ""` (for prefix address search, only saved when `--address-search` is enabled)

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub jsonrpc_import: bool,
     pub light_mode: bool,
     pub address_search: bool,
+    pub index_unspendables: bool,
     pub cors: Option<String>,
     pub precache_scripts: Option<String>,
     pub utxos_limit: usize,
@@ -147,6 +148,11 @@ impl Config {
                 Arg::with_name("address_search")
                     .long("address-search")
                     .help("Enable prefix address search")
+            )
+            .arg(
+                Arg::with_name("index_unspendables")
+                    .long("index-unspendables")
+                    .help("Enable indexing of provably unspendable outputs")
             )
             .arg(
                 Arg::with_name("cors")
@@ -362,6 +368,7 @@ impl Config {
             jsonrpc_import: m.is_present("jsonrpc_import"),
             light_mode: m.is_present("light_mode"),
             address_search: m.is_present("address_search"),
+            index_unspendables: m.is_present("index_unspendables"),
             cors: m.value_of("cors").map(|s| s.to_string()),
             precache_scripts: m.value_of("precache_scripts").map(|s| s.to_string()),
 

--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -378,12 +378,14 @@ impl Mempool {
                 )
             });
 
+            let config = &self.config;
+
             // An iterator over (ScriptHash, TxHistoryInfo)
             let funding = tx
                 .output
                 .iter()
                 .enumerate()
-                .filter(|(_, txo)| is_spendable(txo))
+                .filter(|(_, txo)| is_spendable(txo) || config.index_unspendables)
                 .map(|(index, txo)| {
                     (
                         compute_script_hash(&txo.script_pubkey),

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -169,6 +169,7 @@ pub struct Indexer {
 struct IndexerConfig {
     light_mode: bool,
     address_search: bool,
+    index_unspendables: bool,
     network: Network,
     #[cfg(feature = "liquid")]
     parent_network: Network,
@@ -179,6 +180,7 @@ impl From<&Config> for IndexerConfig {
         IndexerConfig {
             light_mode: config.light_mode,
             address_search: config.address_search,
+            index_unspendables: config.index_unspendables,
             network: config.network_type,
             #[cfg(feature = "liquid")]
             parent_network: config.parent_network,
@@ -1072,7 +1074,7 @@ fn index_transaction(
     //      S{funding-txid:vout}{spending-txid:vin} → ""
     let txid = full_hash(&tx.txid()[..]);
     for (txo_index, txo) in tx.output.iter().enumerate() {
-        if is_spendable(txo) {
+        if is_spendable(txo) || iconfig.index_unspendables {
             let history = TxHistoryRow::new(
                 &txo.script_pubkey,
                 confirmed_height,


### PR DESCRIPTION
Follow up to this conversation: https://github.com/Blockstream/esplora/issues/267

Adds a CLI flag (`--index-unspendables`) that relaxes filtering for transactions that will be indexed in electrs. More specifically, when this flag is enabled transactions with provably unspendable outputs are also indexed.