### PR TITLE
Remove deprecated API of bincode module.

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -35,6 +35,7 @@ use crate::new_index::fetch::{start_fetcher, BlockEntry, FetchFrom};
 
 #[cfg(feature = "liquid")]
 use crate::elements::{asset, peg};
+use bincode::Options;
 
 const MIN_HISTORY_ITEMS_TO_CACHE: usize = 100;
 
@@ -1439,22 +1440,25 @@ impl TxHistoryRow {
     }
 
     fn prefix_height(code: u8, hash: &[u8], height: u32) -> Bytes {
-        bincode::config()
-            .big_endian()
+        bincode::options()
+            .with_big_endian()
             .serialize(&(code, full_hash(&hash[..]), height))
             .unwrap()
     }
 
     pub fn into_row(self) -> DBRow {
         DBRow {
-            key: bincode::config().big_endian().serialize(&self.key).unwrap(),
+            key: bincode::options()
+                .with_big_endian()
+                .serialize(&self.key)
+                .unwrap(),
             value: vec![],
         }
     }
 
     pub fn from_row(row: DBRow) -> Self {
-        let key = bincode::config()
-            .big_endian()
+        let key = bincode::options()
+            .with_big_endian()
             .deserialize(&row.key)
             .expect("failed to deserialize TxHistoryKey");
         TxHistoryRow { key }


### PR DESCRIPTION
This PR is an API migration from a deprecated API that is `bincode::config()` to
new API that is `bincode::option()`

The following warning is removed during the building operation

```bash
warning: use of deprecated function `bincode::config`: please use `options()` instead
    --> src/new_index/schema.rs:1442:9
     |
1442 |         bincode::config()
     |         ^^^^^^^^^^^^^^^
     |
     = note: `#[warn(deprecated)]` on by default

warning: use of deprecated function `bincode::config`: please use `options()` instead
    --> src/new_index/schema.rs:1450:18
     |
1450 |             key: bincode::config().big_endian().serialize(&self.key).unwrap(),
     |                  ^^^^^^^^^^^^^^^

warning: use of deprecated function `bincode::config`: please use `options()` instead
    --> src/new_index/schema.rs:1456:19
     |
1456 |         let key = bincode::config()
     |                   ^^^^^^^^^^^^^^^

warning: 3 warnings emitted
```

I hope this can be helpful