### PR TITLE
Implement blockchain.transaction.get verbose support

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -509,6 +509,13 @@ impl Daemon {
         )
     }
 
+    pub fn gettransaction_raw_verbose(&self, txid: &Txid) -> Result<Value> {
+        self.request(
+            "getrawtransaction",
+            json!([txid.to_hex(), 1]),
+        )
+    }
+
     pub fn getmempooltx(&self, txhash: &Txid) -> Result<Transaction> {
         let value = self.request(
             "getrawtransaction",

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -338,14 +338,13 @@ impl Connection {
     fn blockchain_transaction_get(&self, params: &[Value]) -> Result<Value> {
         let tx_hash = Txid::from(hash_from_value(params.get(0)).chain_err(|| "bad tx_hash")?);
 
-        let mut verbose = false;
-        match params.get(1) {
+        let verbose = match params.get(1) {
             Some(value) => if value == 1 || value == "1" {
-                    verbose = true;
+                    true
                 } else {
-                    verbose = value.as_bool().chain_err(|| "non-bool verbose value")?;
+                    value.as_bool().chain_err(|| "non-bool verbose value")?
                 },
-            None => verbose = false,
+            None => false,
         };
 
         if verbose {

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -337,21 +337,30 @@ impl Connection {
 
     fn blockchain_transaction_get(&self, params: &[Value]) -> Result<Value> {
         let tx_hash = Txid::from(hash_from_value(params.get(0)).chain_err(|| "bad tx_hash")?);
-        let verbose = match params.get(1) {
-            Some(value) => value.as_bool().chain_err(|| "non-bool verbose value")?,
-            None => false,
+
+        let mut verbose = false;
+        match params.get(1) {
+            Some(value) => if value == 1 || value == "1" {
+                    verbose = true;
+                } else {
+                    verbose = value.as_bool().chain_err(|| "non-bool verbose value")?;
+                },
+            None => verbose = false,
         };
 
-        // FIXME: implement verbose support
         if verbose {
-            bail!("verbose transactions are currently unsupported");
+            let tx = self
+                .query
+                .lookup_raw_txn_verbose(&tx_hash)
+                .chain_err(|| "missing transaction")?;
+            Ok(json!(tx))
+        } else {
+            let tx = self
+                .query
+                .lookup_raw_txn(&tx_hash)
+                .chain_err(|| "missing transaction")?;
+            Ok(json!(hex::encode(tx)))
         }
-
-        let tx = self
-            .query
-            .lookup_raw_txn(&tx_hash)
-            .chain_err(|| "missing transaction")?;
-        Ok(json!(hex::encode(tx)))
     }
 
     fn blockchain_transaction_get_merkle(&self, params: &[Value]) -> Result<Value> {

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -4,6 +4,8 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 use std::time::{Duration, Instant};
 
+use serde_json::{from_str, Value};
+
 use crate::chain::{Network, OutPoint, Transaction, TxOut};
 use crate::config::Config;
 use crate::daemon::Daemon;
@@ -114,10 +116,15 @@ impl Query {
             .lookup_txn(txid, None)
             .or_else(|| self.mempool().lookup_txn(txid))
     }
+
     pub fn lookup_raw_txn(&self, txid: &Txid) -> Option<Bytes> {
         self.chain
             .lookup_raw_txn(txid, None)
             .or_else(|| self.mempool().lookup_raw_txn(txid))
+    }
+
+    pub fn lookup_raw_txn_verbose(&self, txid: &Txid) -> Result<Value> {
+        self.daemon.gettransaction_raw_verbose(txid)
     }
 
     pub fn lookup_txos(&self, outpoints: &BTreeSet<OutPoint>) -> HashMap<OutPoint, TxOut> {

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 use std::time::{Duration, Instant};
 
-use serde_json::{from_str, Value};
+use serde_json::{Value};
 
 use crate::chain::{Network, OutPoint, Transaction, TxOut};
 use crate::config::Config;


### PR DESCRIPTION
Added verbose support to blockchain.transaction.get.
It is necessary to set `txindex=1` in the .conf file of coind.
Verbose support is required when used as a backend for AtomicDEX (https://atomicdex.io/).