### PR TITLE
mod unknown method

### DIFF
--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -389,6 +389,10 @@ impl Connection {
             "merkle" : merkle}))
     }
 
+    fn unknown_method(&self, method: &str) -> Result<Value> {
+        Ok(json!(format!("unknown method {}", method)))
+    }
+
     fn handle_command(&mut self, method: &str, params: &[Value], id: &Value) -> Result<Value> {
         let timer = self
             .stats
@@ -424,7 +428,7 @@ impl Connection {
             #[cfg(feature = "electrum-discovery")]
             "server.add_peer" => self.server_add_peer(&params),
 
-            &_ => bail!("unknown method {} {:?}", method, params),
+            &_ => self.unknown_method(&method),
         };
         timer.observe_duration();
         // TODO: return application errors should be sent to the client


### PR DESCRIPTION
Some people access the electrs server using the unknown method, which is obsolete in electrum. It's unclear if this is due to a very old wallet or a homebrew application.
Currently, the unknown method is treated as an error and the peer is disconnected. But these peers reconnect every 10 seconds or every minute.
```
thread 'acceptor' panicked at 'accept failed: Os { code: 24, kind: Other, message: "Too many open files" }', src/electrum/server.rs:660:56
```
There seems to be something wrong with the error handling. However, I think there is also an idea that access by unknown method is not processed as an error.
This proposal simply returns a message for access using the unknown method. This drastically reduced the occurrence of "ERROR".