### PR TITLE
Add the `/headers[/:from_hash[/:count]]` endpoint

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -424,6 +424,25 @@ impl ChainQuery {
         }
     }
 
+    pub fn get_headers(&self, from: &BlockHash, count: usize) -> Option<Vec<BlockHeader>> {
+        let _timer = self.start_timer("get_headers");
+        let store = self.store.indexed_headers.read().unwrap();
+
+        if let Some(from_header) = store.header_by_blockhash(from) {
+            Some(
+                store
+                    .iter()
+                    .rev()
+                    .skip(self.best_height() - from_header.height())
+                    .take(count)
+                    .map(|e| e.header().clone())
+                    .collect(),
+            )
+        } else {
+            None
+        }
+    }
+
     pub fn get_block_header(&self, hash: &BlockHash) -> Option<BlockHeader> {
         let _timer = self.start_timer("get_block_header");
         Some(self.header_by_hash(hash)?.header().clone())


### PR DESCRIPTION
Opening this as a draft to gather some feedback. I'm pretty sure this won't compile on liquid right now, but I didn't want to invest too much time getting it to run in case there's no interest for this from your end.

----

Add a new endpoint to download headers in bulk, up to 2000 with a single
request.

Headers are returned in binary form, with the VarInt-encoded number of
items in the body preceeding them.

By default `from_hash` is the current best hash, but a different
starting block can be specified.

The returned list goes "backwards" returning the `count - 1` blocks
*before* `from_hash` plus the header of `from_hash` itself. This allows
caching the response indefinitely, since it's guaranteed that the
headers that come before a given block will never change.

Returns an error if `from_hash` is not a valid block or it isn't found
in the blockchain.

If `count` is greater than the limit of `2000` it will be silently
capped to said value.