### PR TITLE
Label P2TR outputs as such

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,12 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
+name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
@@ -88,12 +94,6 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
-name = "bech32"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
 name = "bech32"
@@ -131,23 +131,11 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6742ec672d3f12506f4ac5c0d853926ff1f94e675f60ffd3224039972bf663f1"
-dependencies = [
- "bech32 0.7.3",
- "bitcoin_hashes 0.9.7",
- "secp256k1",
- "serde 1.0.127",
-]
-
-[[package]]
-name = "bitcoin"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a427b27dae305157520d86673f2393b3eb08d880609abfcffc6e3c3c820e764"
 dependencies = [
- "bech32 0.8.1",
+ "bech32",
  "bitcoin_hashes 0.10.0",
  "secp256k1",
  "serde 1.0.127",
@@ -164,9 +152,6 @@ name = "bitcoin_hashes"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1"
-dependencies = [
- "serde 1.0.127",
-]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -283,6 +268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,7 +360,7 @@ dependencies = [
  "arrayref",
  "base64 0.13.0",
  "bincode",
- "bitcoin 0.26.2",
+ "bitcoin",
  "clap",
  "crossbeam-channel",
  "dirs",
@@ -407,7 +401,7 @@ name = "electrum-client"
 version = "0.8.0"
 source = "git+https://github.com/Blockstream/rust-electrum-client?rev=d3792352992a539afffbe11501d1aff9fd5b919d#d3792352992a539afffbe11501d1aff9fd5b919d"
 dependencies = [
- "bitcoin 0.27.0",
+ "bitcoin",
  "log",
  "rustls",
  "serde 1.0.127",
@@ -419,12 +413,12 @@ dependencies = [
 
 [[package]]
 name = "elements"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77124f1ecdbeb92691beae289c44553df24c94c86dd3bc07a7037c2064ac3d3"
+version = "0.18.0"
+source = "git+https://github.com/ElementsProject/rust-elements?rev=53d5729f8cdc3623f9f110edba86aeaa9059af5b#53d5729f8cdc3623f9f110edba86aeaa9059af5b"
 dependencies = [
- "bitcoin 0.26.2",
- "bitcoin_hashes 0.9.7",
+ "bitcoin",
+ "bitcoin_hashes 0.10.0",
+ "secp256k1-zkp",
  "serde 1.0.127",
  "serde_json 0.9.10",
  "slip21",
@@ -510,7 +504,7 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -529,7 +523,7 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "futures-core",
  "futures-macro",
  "futures-task",
@@ -799,7 +793,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -809,7 +803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -861,7 +855,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "num-traits 0.2.14",
 ]
 
@@ -880,7 +874,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1075,14 +1069,43 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc",
+ "rand_hc 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1121,6 +1144,15 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
@@ -1129,12 +1161,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -1312,6 +1397,8 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
 dependencies = [
+ "bitcoin_hashes 0.9.7",
+ "rand 0.6.5",
  "secp256k1-sys",
  "serde 1.0.127",
 ]
@@ -1323,6 +1410,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "secp256k1-zkp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e57b977141f57b224fc579c23dac5978b5f594281450fe8b5e2b6aa816d0fde"
+dependencies = [
+ "bitcoin_hashes 0.9.7",
+ "rand 0.6.5",
+ "secp256k1",
+ "secp256k1-zkp-sys",
+ "serde 1.0.127",
+]
+
+[[package]]
+name = "secp256k1-zkp-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45a3c4e1291985397df9770f864ed88bd51ee684b13a384f49d2fedb29f86f0"
+dependencies = [
+ "cc",
+ "secp256k1-sys",
 ]
 
 [[package]]
@@ -1611,7 +1721,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "libc",
  "mio",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ arraydeque = "0.4"
 arrayref = "0.3.6"
 base64 = "0.13.0"
 bincode = "1.3.1"
-bitcoin = { version = "0.26.0", features = [ "use-serde" ] }
+bitcoin = { version = "0.27", features = [ "use-serde" ] }
 clap = "2.33.3"
 crossbeam-channel = "0.5.0"
 dirs = "3.0.1"
-elements = { version = "0.16.0", features = [ "serde-feature" ], optional = true }
+elements = { version = "0.18", features = [ "serde-feature" ], optional = true }
 error-chain = "0.12.4"
 glob = "0.3"
 hex = "0.4.2"
@@ -71,3 +71,8 @@ codegen-units = 1
 [patch.crates-io.electrum-client]
 git = "https://github.com/Blockstream/rust-electrum-client"
 rev = "d3792352992a539afffbe11501d1aff9fd5b919d" # add-peer branch
+
+# needed for https://github.com/ElementsProject/rust-elements/pull/98 until a new release is made
+[patch.crates-io.elements]
+git = "https://github.com/ElementsProject/rust-elements"
+rev = "53d5729f8cdc3623f9f110edba86aeaa9059af5b"

--- a/src/elements/asset.rs
+++ b/src/elements/asset.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, RwLock};
 use bitcoin::hashes::{hex::FromHex, sha256, Hash};
 use elements::confidential::{Asset, Value};
 use elements::encode::{deserialize, serialize};
+use elements::secp256k1_zkp::ZERO_TWEAK;
 use elements::{issuance::ContractHash, AssetId, AssetIssuance, OutPoint, Transaction, TxIn};
 
 use crate::chain::{BNetwork, BlockHash, Network, Txid};
@@ -278,7 +279,7 @@ fn index_tx_assets(
                 }),
             ));
         } else if txi.has_issuance() {
-            let is_reissuance = txi.asset_issuance.asset_blinding_nonce != [0u8; 32];
+            let is_reissuance = txi.asset_issuance.asset_blinding_nonce != ZERO_TWEAK;
 
             let asset_entropy = get_issuance_entropy(txi).expect("invalid issuance");
             let asset_id = AssetId::from_entropy(asset_entropy);
@@ -395,7 +396,7 @@ pub fn get_issuance_entropy(txin: &TxIn) -> Result<sha256::Midstate> {
         bail!("input has no issuance");
     }
 
-    let is_reissuance = txin.asset_issuance.asset_blinding_nonce != [0u8; 32];
+    let is_reissuance = txin.asset_issuance.asset_blinding_nonce != ZERO_TWEAK;
 
     Ok(if !is_reissuance {
         let contract_hash = ContractHash::from_slice(&txin.asset_issuance.asset_entropy)

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -1,4 +1,5 @@
 use bitcoin::hashes::{hex::ToHex, Hash};
+use elements::secp256k1_zkp::ZERO_TWEAK;
 use elements::{confidential::Value, encode::serialize, issuance::ContractHash, AssetId, TxIn};
 
 pub mod asset;
@@ -31,7 +32,7 @@ pub struct IssuanceValue {
 impl From<&TxIn> for IssuanceValue {
     fn from(txin: &TxIn) -> Self {
         let issuance = &txin.asset_issuance;
-        let is_reissuance = issuance.asset_blinding_nonce != [0u8; 32];
+        let is_reissuance = issuance.asset_blinding_nonce != ZERO_TWEAK;
 
         let asset_entropy = get_issuance_entropy(txin).expect("invalid issuance");
         let asset_id = AssetId::from_entropy(asset_entropy);
@@ -48,7 +49,7 @@ impl From<&TxIn> for IssuanceValue {
             contract_hash: contract_hash.map(|h| h.to_hex()),
             is_reissuance,
             asset_blinding_nonce: if is_reissuance {
-                Some(hex::encode(issuance.asset_blinding_nonce))
+                Some(hex::encode(issuance.asset_blinding_nonce.as_ref()))
             } else {
                 None
             },

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -915,12 +915,11 @@ impl ChainQuery {
         let blockid = self.tx_confirming_block(txid)?;
         let headerentry = self.header_by_hash(&blockid.hash)?;
         let block_txids = self.get_block_txids(&blockid.hash)?;
-        let match_txids = vec![*txid].into_iter().collect();
 
-        Some(MerkleBlock::from_header_txids(
+        Some(MerkleBlock::from_header_txids_with_predicate(
             headerentry.header(),
             &block_txids,
-            &match_txids,
+            |t| t == txid,
         ))
     }
 

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -11,6 +11,7 @@ use crate::util::{
 #[cfg(not(feature = "liquid"))]
 use {bitcoin::consensus::encode, std::str::FromStr};
 
+use bitcoin::blockdata::opcodes;
 use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::hashes::Error as HashError;
 use hex::{self, FromHexError};
@@ -318,6 +319,8 @@ impl TxOutValue {
             "v0_p2wpkh"
         } else if script.is_v0_p2wsh() {
             "v0_p2wsh"
+        } else if is_v1_p2tr(script) {
+            "v1_p2tr"
         } else if script.is_provably_unspendable() {
             "provably_unspendable"
         } else {
@@ -343,6 +346,12 @@ impl TxOutValue {
             pegout,
         }
     }
+}
+
+fn is_v1_p2tr(script: &Script) -> bool {
+    script.len() == 34
+        && script[0] == opcodes::all::OP_PUSHNUM_1.into_u8()
+        && script[1] == opcodes::all::OP_PUSHBYTES_32.into_u8()
 }
 
 #[derive(Serialize)]

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -436,9 +436,12 @@ impl From<Utxo> for UtxoValue {
                 _ => None,
             },
             #[cfg(feature = "liquid")]
-            surjection_proof: utxo.witness.surjection_proof,
+            surjection_proof: utxo
+                .witness
+                .surjection_proof
+                .map_or(vec![], |p| p.serialize()),
             #[cfg(feature = "liquid")]
-            range_proof: utxo.witness.rangeproof,
+            range_proof: utxo.witness.rangeproof.map_or(vec![], |p| p.serialize()),
         }
     }
 }


### PR DESCRIPTION
This also reverts e3a819e0743a1a18907646dd99f3e233163cb6ba and re-upgrades rust-bitcoin, because v0.27 is necessary for bech32m support.