### PR TITLE
fix: Abnormal return value from blockchain_scripthash_get_balance

### DIFF
--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -285,9 +285,14 @@ impl Connection {
         let script_hash = hash_from_value(params.get(0)).chain_err(|| "bad script_hash")?;
         let (chain_stats, mempool_stats) = self.query.stats(&script_hash[..]);
 
+        let chain_funded_sum = chain_stats.funded_txo_sum as i64;
+        let chain_spent_sum = chain_stats.spent_txo_sum as i64;
+        let mempool_funded_sum = mempool_stats.funded_txo_sum as i64;
+        let mempool_spent_sum = mempool_stats.spent_txo_sum as i64;
+
         Ok(json!({
-            "confirmed": chain_stats.funded_txo_sum - chain_stats.spent_txo_sum,
-            "unconfirmed": mempool_stats.funded_txo_sum as i64 - mempool_stats.spent_txo_sum as i64,
+            "confirmed": chain_funded_sum - chain_spent_sum,
+            "unconfirmed": mempool_funded_sum - mempool_spent_sum,
         }))
     }
 


### PR DESCRIPTION
While the transaction is unconfirmed, blockchain_scripthash_get_balance returns a huge unconfirmed number.
The cause is the subtraction between u64.

ex)
```
{"id":"blk","jsonrpc":"2.0","result":{"confirmed":398056073100,"unconfirmed":18446743675653478516}}
```