### PR TITLE
Add `best_tip_hash` field to `BlockStatus`

### DIFF
--- a/src/rest.rs
+++ b/src/rest.rs
@@ -673,7 +673,8 @@ fn handle_request(
         }
         (&Method::GET, Some(&"block"), Some(hash), Some(&"status"), None, None) => {
             let hash = BlockHash::from_hex(hash)?;
-            let status = query.chain().get_block_status(&hash);
+            let best_tip_hash = query.chain().best_hash();
+            let status = query.chain().get_block_status(&hash, &best_tip_hash);
             let ttl = ttl_by_depth(status.height, query);
             json_response(status, ttl)
         }

--- a/src/util/block.rs
+++ b/src/util/block.rs
@@ -256,22 +256,29 @@ pub struct BlockStatus {
     pub in_best_chain: bool,
     pub height: Option<usize>,
     pub next_best: Option<BlockHash>,
+    pub best_tip_hash: BlockHash,
 }
 
 impl BlockStatus {
-    pub fn confirmed(height: usize, next_best: Option<BlockHash>) -> BlockStatus {
+    pub fn confirmed(
+        height: usize,
+        next_best: Option<BlockHash>,
+        best_tip_hash: BlockHash,
+    ) -> BlockStatus {
         BlockStatus {
             in_best_chain: true,
             height: Some(height),
             next_best,
+            best_tip_hash,
         }
     }
 
-    pub fn orphaned() -> BlockStatus {
+    pub fn orphaned(best_tip_hash: BlockHash) -> BlockStatus {
         BlockStatus {
             in_best_chain: false,
             height: None,
             next_best: None,
+            best_tip_hash,
         }
     }
 }


### PR DESCRIPTION
We add the tip of the best chain known to the block status endpoint.

This useful in order to allow a client issuing a sequence of queries to check whether a reorg happened in-between, i.e., to detect any possible inconsistencies. In particular, this is needed when syncing a Lightning wallet against an Esplora backend where we need to be able to query the status of multiple transactions/blocks in a consistent way.