### PR TITLE
fix stuck `signal.wait` by using a deadline instead of a duration

### DIFF
--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -7,7 +7,7 @@ extern crate electrs;
 use error_chain::ChainedError;
 use std::process;
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use electrs::{
     config::Config,
@@ -103,7 +103,7 @@ fn run_server(config: Arc<Config>) -> Result<()> {
     let electrum_server = ElectrumRPC::start(Arc::clone(&config), Arc::clone(&query), &metrics);
 
     loop {
-        if let Err(err) = signal.wait(Duration::from_secs(5), true) {
+        if let Err(err) = signal.wait(Instant::now() + Duration::from_secs(5), true) {
             info!("stopping server: {}", err);
             rest_server.stop();
             // the electrum server is stopped when dropped

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, BufReader, Lines, Write};
 use std::net::{SocketAddr, TcpStream};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use base64;
 use bitcoin::hashes::hex::{FromHex, ToHex};
@@ -132,7 +132,7 @@ fn tcp_connect(addr: SocketAddr, signal: &Waiter) -> Result<TcpStream> {
             Ok(conn) => return Ok(conn),
             Err(err) => {
                 warn!("failed to connect daemon at {}: {}", addr, err);
-                signal.wait(Duration::from_secs(3), false)?;
+                signal.wait(Instant::now() + Duration::from_secs(3), false)?;
                 continue;
             }
         }
@@ -326,7 +326,7 @@ impl Daemon {
                 info.headers,
                 info.verificationprogress * 100.0
             );
-            signal.wait(Duration::from_secs(5), false)?;
+            signal.wait(Instant::now() + Duration::from_secs(5), false)?;
         }
         Ok(daemon)
     }
@@ -398,7 +398,8 @@ impl Daemon {
             match self.handle_request_batch(method, params_list) {
                 Err(Error(ErrorKind::Connection(msg), _)) => {
                     warn!("reconnecting to bitcoind: {}", msg);
-                    self.signal.wait(Duration::from_secs(3), false)?;
+                    self.signal
+                        .wait(Instant::now() + Duration::from_secs(3), false)?;
                     let mut conn = self.conn.lock().unwrap();
                     *conn = conn.reconnect()?;
                     continue;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,7 +1,7 @@
 use crossbeam_channel as channel;
 use crossbeam_channel::RecvTimeoutError;
-use std::thread;
 use std::time::Duration;
+use std::{thread, time::Instant};
 
 use signal_hook::consts::{SIGINT, SIGTERM, SIGUSR1};
 
@@ -34,14 +34,14 @@ impl Waiter {
             ]),
         }
     }
-    pub fn wait(&self, duration: Duration, accept_sigusr: bool) -> Result<()> {
-        match self.receiver.recv_timeout(duration) {
+    pub fn wait(&self, deadline: Instant, accept_sigusr: bool) -> Result<()> {
+        match self.receiver.recv_deadline(deadline) {
             Ok(sig) if sig == SIGUSR1 => {
                 trace!("notified via SIGUSR1");
                 if accept_sigusr {
                     Ok(())
                 } else {
-                    self.wait(duration, accept_sigusr)
+                    self.wait(deadline, accept_sigusr)
                 }
             }
             Ok(sig) => bail!(ErrorKind::Interrupt(sig)),


### PR DESCRIPTION
## Overview

I've been running a local `electrs` process for some internal smoke tests and hit a small issue when trying to reduce the test time. I noticed that `electrs` reindexes when it's sent a SIGUSR1 signal, so after causing an on-chain event, I'd aggressively trigger a signal + poll e.g. the blockheaders subscription every few hundred ms.

Unfortunately, this didn't work; occassionally a TCP connect attempt would fail in `electrs` and the service would just loop in `signal.wait()` forever until the test timed out :(

## Problem

After some investigation, it seems the problem arises when a SIGUSR1 signal interrupts a `signal.wait` with `accept_sigusr = false`. The timeout `duration` passed to the recursive `signal.wait` call doesn't take into account the already elapsed time.

Then, if SIGUSR1 signals are received more frequently than the the timeout `duration`, the `signal.wait` call will never return because it keeps getting interrupted and resetting the timeout `duration`.

## Fix

A simple fix for this issue is to use an absolute `deadline` instead a relative `duration`. That way, even if the signal gets interrupted, we'll still trigger a `Timeout` at expected time in subsequent interations.