### PR TITLE
Fix overlapping reads issue

### DIFF
--- a/src/elements/asset.rs
+++ b/src/elements/asset.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 
 use bitcoin::hashes::{hex::FromHex, sha256, Hash};
 use elements::confidential::{Asset, Value};
@@ -346,9 +346,14 @@ fn asset_history_row(
     TxHistoryRow { key }
 }
 
+pub enum AssetRegistryLock<'a> {
+    RwLock(&'a Arc<RwLock<AssetRegistry>>),
+    RwLockReadGuard(&'a RwLockReadGuard<'a, AssetRegistry>),
+}
+
 pub fn lookup_asset(
     query: &Query,
-    registry: Option<&Arc<RwLock<AssetRegistry>>>,
+    registry: Option<AssetRegistryLock>,
     asset_id: &AssetId,
     meta: Option<&AssetMeta>, // may optionally be provided if already known
 ) -> Result<Option<LiquidAsset>> {
@@ -376,10 +381,13 @@ pub fn lookup_asset(
     Ok(if let Some(row) = row {
         let reissuance_token = parse_asset_id(&row.reissuance_token);
 
-        let registry = registry.map(|r| r.read().unwrap());
-        let meta = meta
-            .or_else(|| registry.as_ref().and_then(|r| r.get(asset_id)))
-            .cloned();
+        let meta = meta.map(Clone::clone).or_else(|| match registry {
+            Some(AssetRegistryLock::RwLock(rwlock)) => {
+                rwlock.read().unwrap().get(asset_id).cloned()
+            }
+            Some(AssetRegistryLock::RwLockReadGuard(guard)) => guard.get(asset_id).cloned(),
+            None => None,
+        });
         let stats = issued_asset_stats(query, asset_id, &reissuance_token);
         let status = query.get_tx_status(&deserialize(&row.issuance_txid).unwrap());
 

--- a/src/elements/asset.rs
+++ b/src/elements/asset.rs
@@ -368,7 +368,8 @@ pub fn lookup_asset(
     }
 
     let history_db = query.chain().store().history_db();
-    let mempool_issuances = &query.mempool().asset_issuance;
+    let mempool = query.mempool();
+    let mempool_issuances = &mempool.asset_issuance;
 
     let chain_row = history_db
         .get(&[b"i", &asset_id.into_inner()[..]].concat())
@@ -388,7 +389,7 @@ pub fn lookup_asset(
             Some(AssetRegistryLock::RwLockReadGuard(guard)) => guard.get(asset_id).cloned(),
             None => None,
         });
-        let stats = issued_asset_stats(query, asset_id, &reissuance_token);
+        let stats = issued_asset_stats(query.chain(), &mempool, asset_id, &reissuance_token);
         let status = query.get_tx_status(&deserialize(&row.issuance_txid).unwrap());
 
         let asset = IssuedAsset::new(asset_id, row, stats, meta, status);
@@ -468,21 +469,20 @@ fn pegged_asset_stats(query: &Query, asset_id: &AssetId) -> (PeggedAssetStats, P
 
 // Get stats for issued assets
 fn issued_asset_stats(
-    query: &Query,
+    chain: &ChainQuery,
+    mempool: &Mempool,
     asset_id: &AssetId,
     reissuance_token: &AssetId,
 ) -> (IssuedAssetStats, IssuedAssetStats) {
     let afn = apply_issued_asset_stats;
 
-    let chain = query.chain();
     let mut chain_stats = chain_asset_stats(chain, asset_id, afn);
     chain_stats.burned_reissuance_tokens =
         chain_asset_stats(chain, reissuance_token, afn).burned_amount;
 
-    let mempool = query.mempool();
-    let mut mempool_stats = mempool_asset_stats(&mempool, &asset_id, afn);
+    let mut mempool_stats = mempool_asset_stats(mempool, &asset_id, afn);
     mempool_stats.burned_reissuance_tokens =
-        mempool_asset_stats(&mempool, &reissuance_token, afn).burned_amount;
+        mempool_asset_stats(mempool, &reissuance_token, afn).burned_amount;
 
     (chain_stats, mempool_stats)
 }

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -13,7 +13,7 @@ use crate::util::{is_spendable, BlockId, Bytes, TransactionStatus};
 
 #[cfg(feature = "liquid")]
 use crate::{
-    chain::AssetId,
+    chain::{asset::AssetRegistryLock, AssetId},
     elements::{lookup_asset, AssetRegistry, AssetSorting, LiquidAsset},
 };
 
@@ -234,7 +234,12 @@ impl Query {
 
     #[cfg(feature = "liquid")]
     pub fn lookup_asset(&self, asset_id: &AssetId) -> Result<Option<LiquidAsset>> {
-        lookup_asset(&self, self.asset_db.as_ref(), asset_id, None)
+        lookup_asset(
+            self,
+            self.asset_db.as_ref().map(AssetRegistryLock::RwLock),
+            asset_id,
+            None,
+        )
     }
 
     #[cfg(feature = "liquid")]
@@ -253,8 +258,13 @@ impl Query {
         let results = results
             .into_iter()
             .map(|(asset_id, metadata)| {
-                Ok(lookup_asset(&self, None, asset_id, Some(metadata))?
-                    .chain_err(|| "missing registered asset")?)
+                lookup_asset(
+                    self,
+                    Some(AssetRegistryLock::RwLockReadGuard(&asset_db)),
+                    asset_id,
+                    Some(metadata),
+                )?
+                .chain_err(|| "missing registered asset")
             })
             .collect::<Result<Vec<_>>>()?;
         Ok((total_num, results))


### PR DESCRIPTION
## The issue

1. There is one spot where a read lock is taken and while that read lock is still held a new read lock is taken recursively.
2. If the write thread tries to take the write lock between those two recursive reads, the write will wait for the first read to drop, then the second read will wait for the write to drop, but the first read won't drop until the code completes, which it can't because the second read is waiting on the lock....

It only happens occasionally, since the write lock is only taken every 15 seconds, and the problem only occurs IF the write TAKING is exactly between those two read lock takings, since they are pretty close, it's rare.

## Repro

1. Go to the liquid assets page
2. Hit the End key to scroll to bottom of the page
3. Click on a random page number in the pagination links at the bottom.
4. Repeat 2 and 3 at a rate of about 1 link click every 2 seconds at least.
5. After about 1-2 minutes the request will timeout, and the electrs process will deadlock. The GET request needs to be timed and coincide with the write() lock request.

---

## Edit: Found a second dead lock after going over all the RwLocks with a fine toothed comb.

## The issue

1. Every time you look up an asset, it calls `query.mempool()` which returns a RwLockReadGuard. Then later on (within a sub-function called with query passed in) `query.mempool()` is called again. This causes another possibility for the write() in the main loop (src/bin/electrs.rs) to occur between those two reads, causing the whole main loop to freeze.
2. The write() in the main loop must coincide with an asset GET request. The write() is called about once every 500 - 1500 ms. (500ms wait for user signal + the time it takes to query bitcoind for new blocks and mempool txs.)