### PR TITLE
Fix address stats with re-orged history entries

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -675,6 +675,9 @@ impl ChainQuery {
             .map(TxHistoryRow::from_row)
             .filter_map(|history| {
                 self.tx_confirming_block(&history.get_txid())
+                    // drop history entries that were previously confirmed in a re-orged block and later
+                    // confirmed again at a different height
+                    .filter(|blockid| blockid.height == history.key.confirmed_height as usize)
                     .map(|blockid| (history, blockid))
             });
 


### PR DESCRIPTION
There might be history entries where the txid ended up confirming at a different block height following a re-org. Before this fix, these entries would get counted twice, once with the initial re-orged confirmation height, then again with the final confirmation height.

See https://github.com/mempool/electrs/pull/12.