### PR TITLE
Upgrade `librocksdb`/`bindgen` for compatibility with Clang15 (XCode 15)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -127,11 +127,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -196,6 +198,17 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cc"
@@ -373,8 +386,7 @@ dependencies = [
  "page_size",
  "prometheus",
  "rayon",
- "rocksdb 0.12.4",
- "rocksdb 0.17.0",
+ "rocksdb",
  "rust-crypto",
  "serde",
  "serde_derive",
@@ -504,7 +516,7 @@ checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -734,14 +746,29 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.20.3"
+version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c309a9d2470844aceb9a4a098cf5286154d20596868b75a6b36357d2bb9ca25d"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
  "bindgen",
+ "bzip2-sys",
  "cc",
  "glob",
  "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -761,6 +788,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -958,7 +995,7 @@ checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -974,12 +1011,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.37"
+name = "pkg-config"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
- "unicode-xid",
+ "proc-macro2",
+ "syn 2.0.41",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1005,9 +1058,9 @@ checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1235,19 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.12.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65bee9fe606c76fd90d6cc33b86bdafde0981b8a6b2d190ec1267e0d065baf8"
-dependencies = [
- "libc",
- "librocksdb-sys",
-]
-
-[[package]]
-name = "rocksdb"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a62eca5cacf2c8261128631bed9f045598d40bfbe4b29f5163f0f802f8f44a7"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -1398,7 +1441,7 @@ checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1516,6 +1559,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sysconf"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,7 +1630,7 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1667,7 +1721,7 @@ checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1709,6 +1763,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1806,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -1802,7 +1868,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
  "wasm-bindgen-shared",
 ]
 
@@ -1824,7 +1890,7 @@ checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1906,3 +1972,13 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 default = [ "rocksdb" ]
 liquid = [ "elements" ]
 electrum-discovery = [ "electrum-client"]
-oldcpu = [ "rocksdb-oldcpu" ]
 
 [dependencies]
 arraydeque = "0.4"
@@ -39,8 +38,8 @@ num_cpus = "1.12.0"
 page_size = "0.4.2"
 prometheus = "0.13"
 rayon = "1.5.0"
-rocksdb = { version = "0.17.0", optional = true }
-rocksdb-oldcpu = { version = "0.12.4", optional = true, package = "rocksdb" }
+rocksdb = { version = "0.21.0", optional = true }
+
 rust-crypto = "0.2"
 serde = "1.0.118"
 serde_derive = "1.0.118"

--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -50,15 +50,6 @@ impl<'a> Iterator for ScanIterator<'a> {
                 }
             },
         }
-        // let (key, value) = self.iter.next()?;
-        // if !key.starts_with(&self.prefix) {
-        //     self.done = true;
-        //     return None;
-        // }
-        // Some(DBRow {
-        //     key: key.to_vec(),
-        //     value: value.to_vec(),
-        // })
     }
 }
 

--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -26,15 +26,39 @@ impl<'a> Iterator for ScanIterator<'a> {
         if self.done {
             return None;
         }
-        let (key, value) = self.iter.next()?;
-        if !key.starts_with(&self.prefix) {
-            self.done = true;
-            return None;
+        match self.iter.next() {
+            // none arm
+            None => return None,
+            Some(res) => {
+                match res {
+                    // ok arm
+                    Ok((key, value)) => {
+                        if !key.starts_with(&self.prefix) {
+                            // TODO should the work be marked complete here? 
+                            // leaving based on desire to have a minimal footprint on original.
+                            self.done = true;
+                            return None
+                        } else {
+                            // return the expected DBRow
+                            return Some(DBRow { key: key.to_vec(), value: value.to_vec() })
+                        }
+                    },
+                    // error arm
+                    // TODO should do some handling or more research into the downstream handling of None.
+                    // leaving based on desire to have a minimal footprint on original.
+                    Err(_) => return None,
+                }
+            },
         }
-        Some(DBRow {
-            key: key.to_vec(),
-            value: value.to_vec(),
-        })
+        // let (key, value) = self.iter.next()?;
+        // if !key.starts_with(&self.prefix) {
+        //     self.done = true;
+        //     return None;
+        // }
+        // Some(DBRow {
+        //     key: key.to_vec(),
+        //     value: value.to_vec(),
+        // })
     }
 }
 


### PR DESCRIPTION
I was unable to compile a clean copy of `new-index` due to pre-existing dependencies on my machine with the following error:

```
error: failed to run custom build command for `librocksdb-sys v6.20.3`

...

electrs/target/release/build/librocksdb-sys-3b3cba65ffc3c8e0/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at '"enum_(unnamed_at_rocksdb/include/rocksdb/c_h_854_1)" is not a valid Ident'
  ```
  
 I then noticed some other comments/issues around this error message related to an incompatibility with `Clang 15` and Rust `bindgen` (<=`0.62`). With some tinkering and upgrading `rocksdb` to `0.21.0` I'm able to compile and use this in Regtest, but I'm curious if this could be a stub for a larger dependency upgrade that I'd be happy to contribute to. 
 
 The goal was to use `electrs` with a local `bitcoind` Regtest node, derived from Polar (Docker), which works following this change... here are some details of my setup to reproduce the original issue:
 
``` 
OS: MacOS (Intel)
rustc: 1.72.1
cargo: 1.72.1
rustup: 1.26.0
```