### PR TITLE
Add optional structured logs of RPC related events

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ pub struct Config {
     pub utxos_limit: usize,
     pub electrum_txs_limit: usize,
     pub electrum_banner: String,
+    pub rpc_logging: Option<RpcLogging>,
 
     #[cfg(feature = "liquid")]
     pub parent_network: BNetwork,
@@ -65,6 +66,10 @@ fn str_to_socketaddr(address: &str, what: &str) -> SocketAddr {
 impl Config {
     pub fn from_args() -> Config {
         let network_help = format!("Select network type ({})", Network::names().join(", "));
+        let rpc_logging_help = format!(
+            "Select RPC logging option ({})",
+            RpcLogging::options().join(", ")
+        );
 
         let args = App::new("Electrum Rust Server")
             .version(crate_version!())
@@ -181,6 +186,11 @@ impl Config {
                     .long("electrum-banner")
                     .help("Welcome banner for the Electrum server, shown in the console to clients.")
                     .takes_value(true)
+            ).arg(
+                Arg::with_name("rpc_logging")
+                    .long("rpc-logging")
+                    .help(&rpc_logging_help)
+                    .takes_value(true),
             );
 
         #[cfg(unix)]
@@ -381,6 +391,9 @@ impl Config {
             electrum_rpc_addr,
             electrum_txs_limit: value_t_or_exit!(m, "electrum_txs_limit", usize),
             electrum_banner,
+            rpc_logging: m
+                .value_of("rpc_logging")
+                .map(|option| RpcLogging::from(option)),
             http_addr,
             http_socket_file,
             monitoring_addr,
@@ -416,6 +429,29 @@ impl Config {
             Arc::new(CookieFile {
                 daemon_dir: self.daemon_dir.clone(),
             })
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum RpcLogging {
+    Full,
+    NoParams,
+}
+
+impl RpcLogging {
+    pub fn options() -> Vec<String> {
+        return vec!["full".to_string(), "no-params".to_string()];
+    }
+}
+
+impl From<&str> for RpcLogging {
+    fn from(option: &str) -> Self {
+        match option {
+            "full" => RpcLogging::Full,
+            "no-params" => RpcLogging::NoParams,
+
+            _ => panic!("unsupported RPC logging option: {:?}", option),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ pub struct Config {
     pub utxos_limit: usize,
     pub electrum_txs_limit: usize,
     pub electrum_banner: String,
-    pub rpc_logging: Option<RpcLogging>,
+    pub electrum_rpc_logging: Option<RpcLogging>,
 
     #[cfg(feature = "liquid")]
     pub parent_network: BNetwork,
@@ -187,8 +187,8 @@ impl Config {
                     .help("Welcome banner for the Electrum server, shown in the console to clients.")
                     .takes_value(true)
             ).arg(
-                Arg::with_name("rpc_logging")
-                    .long("rpc-logging")
+                Arg::with_name("electrum_rpc_logging")
+                    .long("electrum-rpc-logging")
                     .help(&rpc_logging_help)
                     .takes_value(true),
             );
@@ -391,8 +391,8 @@ impl Config {
             electrum_rpc_addr,
             electrum_txs_limit: value_t_or_exit!(m, "electrum_txs_limit", usize),
             electrum_banner,
-            rpc_logging: m
-                .value_of("rpc_logging")
+            electrum_rpc_logging: m
+                .value_of("electrum_rpc_logging")
                 .map(|option| RpcLogging::from(option)),
             http_addr,
             http_socket_file,

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -547,12 +547,14 @@ impl Connection {
                                     json!({
                                         "event": "rpc request",
                                         "method": method,
-                                        "params": params
+                                        "params": params,
+                                        "id": id
                                     })
                                 } else {
                                     json!({
                                         "event": "rpc request",
-                                        "method": method
+                                        "method": method,
+                                        "id": id
                                     })
                                 }
                             );
@@ -570,7 +572,8 @@ impl Connection {
                         json!({
                             "event": "rpc response",
                             "method": method_info,
-                            "payload_size": line.as_bytes().len()
+                            "payload_size": line.as_bytes().len(),
+                            "id": cmd.get("id").unwrap()
                         })
                     );
 

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -564,7 +564,7 @@ impl Connection {
                                     "event": "rpc response",
                                     "method": method,
                                     "payload_size": reply.to_string().as_bytes().len(),
-                                    "duration_ms": start_time.elapsed().as_millis(),
+                                    "duration_µs": start_time.elapsed().as_micros(),
                                     "id": id,
                                 })
                             );

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -502,24 +502,22 @@ impl Connection {
     }
 
     fn log_rpc_event(&self, entries: &Vec<(&str, Value)>) {
-        if let Some(_) = self.rpc_logging {
-            let mut log = json!({});
+        let mut log = json!({});
 
-            if let Some(log_map) = log.as_object_mut() {
-                entries.into_iter().for_each(|e| {
-                    log_map.insert(e.0.to_string(), e.1.clone());
-                });
-                log_map.insert(
-                    "source".to_string(),
-                    json!({
-                        "ip": self.addr.ip().to_string(),
-                        "port": self.addr.port(),
-                    }),
-                );
-            }
-
-            info!("{}", log);
+        if let Some(log_map) = log.as_object_mut() {
+            entries.into_iter().for_each(|e| {
+                log_map.insert(e.0.to_string(), e.1.clone());
+            });
+            log_map.insert(
+                "source".to_string(),
+                json!({
+                    "ip": self.addr.ip().to_string(),
+                    "port": self.addr.port(),
+                }),
+            );
         }
+
+        info!("{}", log);
     }
 
     fn send_values(&mut self, values: &[Value]) -> Result<()> {

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -501,8 +501,8 @@ impl Connection {
         Ok(result)
     }
 
-    fn log_rpc_event(&self, mut log: HashMap<&str, Value>) {
-        log.insert(
+    fn log_rpc_event(&self, mut log: Value) {
+        log.as_object_mut().unwrap().insert(
             "source".into(),
             json!({
                 "ip": self.addr.ip().to_string(),
@@ -541,15 +541,21 @@ impl Connection {
                             &Value::Array(ref params),
                             Some(ref id),
                         ) => {
-                            conditionally_log_rpc_event!(self, {
-                                let mut log: HashMap<&str, Value> = HashMap::new();
-                                log.insert("event", json!("rpc request"));
-                                log.insert("method", json!(method));
+                            conditionally_log_rpc_event!(
+                                self,
                                 if let Some(RpcLogging::Full) = self.rpc_logging {
-                                    log.insert("params", json!(params));
+                                    json!({
+                                        "event": "rpc request",
+                                        "method": method,
+                                        "params": params
+                                    })
+                                } else {
+                                    json!({
+                                        "event": "rpc request",
+                                        "method": method
+                                    })
                                 }
-                                log
-                            });
+                            );
                             method_info = method.clone();
 
                             self.handle_command(method, params, id)?
@@ -559,13 +565,14 @@ impl Connection {
 
                     let line = reply.to_string() + "\n";
 
-                    conditionally_log_rpc_event!(self, {
-                        let mut log: HashMap<&str, Value> = HashMap::new();
-                        log.insert("event", json!("rpc response"));
-                        log.insert("method", json!(method_info));
-                        log.insert("payload_size", json!(line.as_bytes().len()));
-                        log
-                    });
+                    conditionally_log_rpc_event!(
+                        self,
+                        json!({
+                            "event": "rpc response",
+                            "method": method_info,
+                            "payload_size": line.as_bytes().len()
+                        })
+                    );
 
                     self.send_values(&[reply])?
                 }
@@ -610,11 +617,12 @@ impl Connection {
 
     pub fn run(mut self) {
         self.stats.clients.inc();
-        conditionally_log_rpc_event!(self, {
-            let mut log: HashMap<&str, Value> = HashMap::new();
-            log.insert("event", json!("connection established"));
-            log
-        });
+        conditionally_log_rpc_event!(
+            self,
+            json!({
+                "event": "connection established"
+            })
+        );
 
         let reader = BufReader::new(self.stream.try_clone().expect("failed to clone TcpStream"));
         let tx = self.chan.sender();
@@ -632,11 +640,12 @@ impl Connection {
             .sub(self.status_hashes.len() as i64);
 
         debug!("[{}] shutting down connection", self.addr);
-        conditionally_log_rpc_event!(self, {
-            let mut log: HashMap<&str, Value> = HashMap::new();
-            log.insert("event", json!("connection closed"));
-            log
-        });
+        conditionally_log_rpc_event!(
+            self,
+            json!({
+                "event": "connection closed"
+            })
+        );
 
         let _ = self.stream.shutdown(Shutdown::Both);
         if let Err(err) = child.join().expect("receiver panicked") {

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -4,6 +4,7 @@ use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc::{Sender, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Instant;
 
 use bitcoin::hashes::sha256d::Hash as Sha256dHash;
 use crypto::digest::Digest;
@@ -554,6 +555,7 @@ impl Connection {
                                 })
                             );
 
+                            let start_time = Instant::now();
                             let reply = self.handle_command(method, params, id)?;
 
                             conditionally_log_rpc_event!(
@@ -562,6 +564,7 @@ impl Connection {
                                     "event": "rpc response",
                                     "method": method,
                                     "payload_size": reply.to_string().as_bytes().len(),
+                                    "duration_ms": start_time.elapsed().as_millis(),
                                     "id": id,
                                 })
                             );

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -542,20 +542,16 @@ impl Connection {
                         ) => {
                             conditionally_log_rpc_event!(
                                 self,
-                                if let Some(RpcLogging::Full) = self.rpc_logging {
-                                    json!({
-                                        "event": "rpc request",
-                                        "method": method,
-                                        "params": params,
-                                        "id": id
-                                    })
-                                } else {
-                                    json!({
-                                        "event": "rpc request",
-                                        "method": method,
-                                        "id": id
-                                    })
-                                }
+                                json!({
+                                    "event": "rpc request",
+                                    "id": id,
+                                    "method": method,
+                                    "params": if let Some(RpcLogging::Full) = self.rpc_logging {
+                                        json!(params)
+                                    } else {
+                                        Value::Null
+                                    }
+                                })
                             );
 
                             let reply = self.handle_command(method, params, id)?;
@@ -618,12 +614,7 @@ impl Connection {
 
     pub fn run(mut self) {
         self.stats.clients.inc();
-        conditionally_log_rpc_event!(
-            self,
-            json!({
-                "event": "connection established"
-            })
-        );
+        conditionally_log_rpc_event!(self, json!({ "event": "connection established" }));
 
         let reader = BufReader::new(self.stream.try_clone().expect("failed to clone TcpStream"));
         let tx = self.chan.sender();
@@ -641,12 +632,7 @@ impl Connection {
             .sub(self.status_hashes.len() as i64);
 
         debug!("[{}] shutting down connection", self.addr);
-        conditionally_log_rpc_event!(
-            self,
-            json!({
-                "event": "connection closed"
-            })
-        );
+        conditionally_log_rpc_event!(self, json!({ "event": "connection closed" }));
 
         let _ = self.stream.shutdown(Shutdown::Both);
         if let Err(err) = child.join().expect("receiver panicked") {

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -509,7 +509,7 @@ impl Connection {
                 "port": self.addr.port(),
             }),
         );
-        println!("ELECTRUM-RPC-LOGGER: {}", json!(log));
+        println!("ELECTRUM-RPC-LOGGER: {}", log);
     }
 
     fn send_values(&mut self, values: &[Value]) -> Result<()> {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -105,6 +105,7 @@ impl TestRunner {
             utxos_limit: 100,
             electrum_txs_limit: 100,
             electrum_banner: "".into(),
+            electrum_rpc_logging: None,
 
             #[cfg(feature = "liquid")]
             asset_db_path: None, // XXX


### PR DESCRIPTION
Adding RPC related event logs that will be used in Blockstream Explorer project. The logs are structured as json object. This optional logging may be used in an enterprise/internal scenario for billing purposes. By default it's turned off. 

The logs are controlled with a new `--rpc-logging` command line option. Command line option possible values, and example structured logs they produce, are as following:

- `--rpc-logging full`  results in logs:

```
ELECTRUM-RPC-LOGGER: {"event":"connection established","source":{"ip":"127.0.0.1","port":59877}}
ELECTRUM-RPC-LOGGER: {"event":"rpc request","id":18,"method":"blockchain.scripthash.get_history","params":["6b63eef944d982701eb2d0dbb8ee900f42d8e79fe3d1ea473602c0edc87c34f6"],"source":{"ip":"127.0.0.1","port":59877}}
ELECTRUM-RPC-LOGGER: {"duration_µs":114,"event":"rpc response","id":18,"method":"blockchain.scripthash.get_history","payload_size":37,"source":{"ip":"127.0.0.1","port":59877}}
ELECTRUM-RPC-LOGGER: {"event":"connection closed","source":{"ip":"127.0.0.1","port":59877}}
```

- `--rpc-logging no-params` excludes RPC request params to be logged, results in logs like:

```
ELECTRUM-RPC-LOGGER: {"event":"connection established","source":{"ip":"127.0.0.1","port":59886}}
ELECTRUM-RPC-LOGGER: {"event":"rpc request","id":18,"method":"blockchain.scripthash.get_history","params":null,"source":{"ip":"127.0.0.1","port":59886}}
ELECTRUM-RPC-LOGGER: {"duration_µs":78,"event":"rpc response","id":18,"method":"blockchain.scripthash.get_history","payload_size":37,"source":{"ip":"127.0.0.1","port":59886}}
ELECTRUM-RPC-LOGGER: {"event":"connection closed","source":{"ip":"127.0.0.1","port":59886}}```