### PR TITLE
ci: Use fixed Rust version (v1.75.0)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,9 @@ jobs:
     #- name: Check formatting
     #  run: cargo fmt -- --check
 
+    - name: Setup Rust toolchain
+      run: rustup default 1.75.0
+
     - name: Check for errors
       run: cargo check
 


### PR DESCRIPTION
The latest Rust v1.76.0 released a few days ago is not compatible with rustc-serialize v0.3.24, which [broke the CI](https://github.com/Blockstream/electrs/actions/runs/7855464541/job/21549419012).

rustc-serialize v0.3.25 was released with a fix and was updated to as part of #67, which resolves the issue.

But in order to make CI work until #67 is merged, and since it is preferable to use a fixed Rust version rather than the latest stable anyway, this PR downgrades Rust back to v1.75.0.