### PR TITLE
Removing text prefix that makes the log an invalid json

### DIFF
--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -527,6 +527,7 @@ impl Connection {
         let empty_params = json!([]);
         loop {
             let msg = self.chan.receiver().recv().chain_err(|| "channel closed")?;
+            let start_time = Instant::now();
             trace!("RPC {:?}", msg);
             match msg {
                 Message::Request(line) => {
@@ -555,7 +556,6 @@ impl Connection {
                                 })
                             );
 
-                            let start_time = Instant::now();
                             let reply = self.handle_command(method, params, id)?;
 
                             conditionally_log_rpc_event!(
@@ -564,7 +564,7 @@ impl Connection {
                                     "event": "rpc response",
                                     "method": method,
                                     "payload_size": reply.to_string().as_bytes().len(),
-                                    "duration_µs": start_time.elapsed().as_micros(),
+                                    "duration_micros": start_time.elapsed().as_micros(),
                                     "id": id,
                                 })
                             );

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -510,7 +510,7 @@ impl Connection {
                 "port": self.addr.port(),
             }),
         );
-        println!("ELECTRUM-RPC-LOGGER: {}", log);
+        println!("{}", log);
     }
 
     fn send_values(&mut self, values: &[Value]) -> Result<()> {


### PR DESCRIPTION
`ELECTRUM-RPC-LOGGER: ` prefix causes problem because with it included in the log line the log interpreted as a json is invalid. Therefore a preprocessing that removes this prefix, or reads json with an offset from the log, should be used to fix it. However I think it's better to remove this log prefix.