### PR TITLE
test: enable sandbox build with --no-default-features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,3 +43,6 @@ jobs:
 
     - name: Tests (Liquid mode, REST)
       run: cargo test --features liquid
+
+    - name: Tests (no default features)
+      run: cargo test --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ readme = "README.md"
 edition = "2018"
 
 [features]
+default = [ "dev" ]
 liquid = [ "elements" ]
 electrum-discovery = [ "electrum-client"]
+dev = [ "bitcoind/25_0", "electrumd/4_1_5", "elementsd/22_1_1" ]
 
 [dependencies]
 arraydeque = "0.5.1"
@@ -58,9 +60,9 @@ electrum-client = { version = "0.8", optional = true }
 
 
 [dev-dependencies]
-bitcoind = { version = "0.34", features = [ "25_0" ] }
-elementsd = { version = "0.9", features = [ "22_1_1" ] }
-electrumd = { version = "0.1.0", features = [ "4_1_5" ] }
+bitcoind = { version = "0.34" }
+elementsd = { version = "0.9" }
+electrumd = { version = "0.1.0" }
 ureq = { version = "2.9", default-features = false, features = [ "json" ] }
 tempfile = "3.10"
 

--- a/tests/electrum.rs
+++ b/tests/electrum.rs
@@ -12,8 +12,8 @@ use bitcoin::address;
 
 /// Test the Electrum RPC server using an headless Electrum wallet
 /// This only runs on Bitcoin (non-Liquid) mode.
-#[cfg_attr(not(feature = "liquid"), test)]
-#[cfg_attr(feature = "liquid", allow(dead_code))]
+#[cfg_attr(all(feature = "dev", not(feature = "liquid")), test)]
+#[cfg_attr(any(feature = "liquid", not(feature = "dev")), allow(dead_code))]
 fn test_electrum() -> Result<()> {
     // Spawn an Electrs Electrum RPC server
     let (electrum_server, electrum_addr, mut tester) = common::init_electrum_tester().unwrap();

--- a/tests/rest.rs
+++ b/tests/rest.rs
@@ -8,7 +8,8 @@ pub mod common;
 
 use common::Result;
 
-#[test]
+#[cfg_attr(feature = "dev", test)]
+#[cfg_attr(not(feature = "dev"), allow(dead_code))]
 fn test_rest() -> Result<()> {
     let (rest_handle, rest_addr, mut tester) = common::init_rest_tester().unwrap();
 


### PR DESCRIPTION
I'm making a [nixpkgs](/nixos/nixpkgs) derivation for this repo, which is built in a sandbox with no network access. 

This PR allows tests to be run with `--no-default-features` to disable the binary downloads in the bitcoind, elementsd, and electrumd dev dependencies. Default features will still download them.