### PR TITLE
Optimize txo lookup

### DIFF
--- a/src/bin/tx-fingerprint-stats.rs
+++ b/src/bin/tx-fingerprint-stats.rs
@@ -83,12 +83,12 @@ fn main() {
         //info!("{:?},{:?}", txid, blockid);
 
         let prevouts = chain.lookup_txos(
-            &tx.input
+            tx.input
                 .iter()
                 .filter(|txin| has_prevout(txin))
                 .map(|txin| txin.previous_output)
                 .collect(),
-        );
+        ).unwrap();
 
         let total_out: u64 = tx.output.iter().map(|out| out.value.to_sat()).sum();
         let small_out = tx

--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -196,6 +196,14 @@ impl DB {
         self.db.get(key).unwrap().map(|v| v.to_vec())
     }
 
+    pub fn multi_get<K, I>(&self, keys: I) -> Vec<Result<Option<Vec<u8>>, rocksdb::Error>>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
+    {
+        self.db.multi_get(keys)
+    }
+
     fn verify_compatibility(&self, config: &Config) {
         let mut compatibility_bytes = bincode::serialize_little(&DB_VERSION).unwrap();
 

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -118,7 +118,7 @@ impl Query {
             .or_else(|| self.mempool().lookup_raw_txn(txid))
     }
 
-    pub fn lookup_txos(&self, outpoints: &BTreeSet<OutPoint>) -> HashMap<OutPoint, TxOut> {
+    pub fn lookup_txos(&self, outpoints: BTreeSet<OutPoint>) -> HashMap<OutPoint, TxOut> {
         // the mempool lookup_txos() internally looks up confirmed txos as well
         self.mempool()
             .lookup_txos(outpoints)

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -468,7 +468,7 @@ fn prepare_txs(
         })
         .collect();
 
-    let prevouts = query.lookup_txos(&outpoints);
+    let prevouts = query.lookup_txos(outpoints);
 
     txs.into_iter()
         .map(|(tx, blockid)| TransactionValue::new(tx, blockid, &prevouts, config))


### PR DESCRIPTION
From https://github.com/facebook/rocksdb/wiki/MultiGet-Performance:

> There is a lot of complexity in the underlying RocksDB implementation to lookup a key. The complexity results in a lot of computational overhead, mainly due to cache misses when probing bloom filters, virtual function call dispatches, key comparisons and IO. Users that need to lookup many keys in order to process an application level request end up calling Get() in a loop to read the required KVs. 
>
> By providing a MultiGet() API that accepts a batch of keys, it is possible for RocksDB to make the lookup more CPU efficient by reducing the number of virtual function calls and pipelining cache misses. Furthermore, latency can be reduced by doing IO in parallel.