### PR TITLE
Split up mempool fetch and mempool write

### DIFF
--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -492,6 +492,8 @@ impl Mempool {
     }
 
     pub fn update(mempool: &Arc<RwLock<Mempool>>, daemon: &Daemon) -> Result<()> {
+        let _timer = mempool.read().unwrap().latency.with_label_values(&["update"]).start_timer();
+
         // 1. Determine which transactions are no longer in the daemon's mempool and which ones have newly entered it
         let old_txids = mempool.read().unwrap().old_txids();
         let all_txids = daemon

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -161,7 +161,7 @@ impl TestRunner {
             &metrics,
             Arc::clone(&config),
         )));
-        mempool.write().unwrap().update(&daemon)?;
+        Mempool::update(&mempool, &daemon)?;
 
         let query = Arc::new(Query::new(
             Arc::clone(&chain),
@@ -193,10 +193,9 @@ impl TestRunner {
 
     pub fn sync(&mut self) -> Result<()> {
         self.indexer.update(&self.daemon)?;
-        let mut mempool = self.mempool.write().unwrap();
-        mempool.update(&self.daemon)?;
+        Mempool::update(&self.mempool, &self.daemon)?;
         // force an update for the mempool stats, which are normally cached
-        mempool.update_backlog_stats();
+        self.mempool.write().unwrap().update_backlog_stats();
         Ok(())
     }
 


### PR DESCRIPTION
Currently, the mempool's lock is acquired before doing the following steps to update the in-memory version of the mempool:
1. Fetch the old mempool's TXIDs from disk
2. Fetch the new mempool's TXIDs over RPC
3. Fetch the full transactions of the new TXIDs
4. Write the new transactions to the in-memory transaction index 

Right now, all four steps are done while holding a write lock on the mempool.
We suspect that this is causing incoming requests which read from the query's mempool to fail, because steps 1 - 4 together

In reality, step 1 only needs a read lock on the mempool, step 2 and 3 need no lock and only step 4 needs the write lock.
This PR updates the code to only acquire a write lock for step 4.

It also adds logging around each step, so that we can more-easily see were the bottlenecks are when long response times occasionally occur.

Since the lock is dropped between step 1 and step 4, this opens up potential consistency issues. However, step 4 is the only thing which updates the mempool -- no updates come from other threads, so this shouldn't cause any issues. 