### PR TITLE
Build with nix flake

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,3 +43,6 @@ jobs:
 
     - name: Tests (Liquid mode, REST)
       run: cargo test --features liquid
+
+    - name: Tests (no default features)
+      run: cargo test --no-default-features

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 *.sublime*
 *~
 *.pyc
+result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ readme = "README.md"
 edition = "2018"
 
 [features]
+default = [ "dev" ]
 liquid = [ "elements" ]
 electrum-discovery = [ "electrum-client"]
+dev = [ "bitcoind/25_0", "electrumd/4_1_5", "elementsd/22_1_1" ]
 
 [dependencies]
 arraydeque = "0.5.1"
@@ -58,9 +60,9 @@ electrum-client = { version = "0.8", optional = true }
 
 
 [dev-dependencies]
-bitcoind = { version = "0.34", features = [ "25_0" ] }
-elementsd = { version = "0.9", features = [ "22_1_1" ] }
-electrumd = { version = "0.1.0", features = [ "4_1_5" ] }
+bitcoind = { version = "0.34" }
+elementsd = { version = "0.9" }
+electrumd = { version = "0.1.0" }
 ureq = { version = "2.9", default-features = false, features = [ "json" ] }
 tempfile = "3.10"
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,106 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1711586303,
+        "narHash": "sha256-iZDHWTqQj6z6ccqTSEOPOxQ8KMFAemInUObN2R9vHSs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "a329cd00398379c62e76fc3b8d4ec2934260d636",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711523803,
+        "narHash": "sha256-UKcYiHWHQynzj6CN/vTcix4yd1eCu1uFdsuarupdCQQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2726f127c15a4cc9810843b96cad73c7eb39e443",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1711592024,
+        "narHash": "sha256-oD4OJ3TRmVrbAuKZWxElRCyCagNCDuhfw2exBmNOy48=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "aa858717377db2ed8ffd2d44147d907baee656e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+  };
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, crane }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+          rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+          craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+          src = craneLib.cleanCargoSource ./.; 
+
+          nativeBuildInputs = with pkgs; [ rustToolchain clang ]; # required only at build time
+          buildInputs = with pkgs; [ ]; # also required at runtime
+
+          commonArgs = {
+            inherit src buildInputs nativeBuildInputs;
+            cargoExtraArgs = "--no-default-features";  # avoid autodownload feature, which cannot happen in nix for deterministism
+            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+          };
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          bin = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+            # doCheck = false;
+          });
+
+        in
+        with pkgs;
+        {
+          packages =
+            {
+              # that way we can build `bin` specifically,
+              # but it's also the default.
+              inherit bin;
+              default = bin;
+            };
+
+          devShells.default = mkShell {
+            inputsFrom = [ bin ];
+          };
+        }
+      );
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.75.0"

--- a/tests/electrum.rs
+++ b/tests/electrum.rs
@@ -12,8 +12,8 @@ use bitcoin::address;
 
 /// Test the Electrum RPC server using an headless Electrum wallet
 /// This only runs on Bitcoin (non-Liquid) mode.
-#[cfg_attr(not(feature = "liquid"), test)]
-#[cfg_attr(feature = "liquid", allow(dead_code))]
+#[cfg_attr(all(feature = "dev", not(feature = "liquid")), test)]
+#[cfg_attr(any(feature = "liquid", not(feature = "dev")), allow(dead_code))]
 fn test_electrum() -> Result<()> {
     // Spawn an Electrs Electrum RPC server
     let (electrum_server, electrum_addr, mut tester) = common::init_electrum_tester().unwrap();

--- a/tests/rest.rs
+++ b/tests/rest.rs
@@ -8,7 +8,8 @@ pub mod common;
 
 use common::Result;
 
-#[test]
+#[cfg_attr(feature = "dev", test)]
+#[cfg_attr(not(feature = "dev"), allow(dead_code))]
 fn test_rest() -> Result<()> {
     let (rest_handle, rest_addr, mut tester) = common::init_rest_tester().unwrap();
 


### PR DESCRIPTION
on top of #73 (which has been closed, but I think it should be re-considered https://github.com/Blockstream/electrs/pull/73#issuecomment-2025204742)

Enable builds using flakes with

```
nix build
```

This enables downstream users to reference the flake from the blocstream repo directly since https://github.com/NixOS/nixpkgs/pull/299761 may take undefined amount of time