### PR TITLE
enable build with nix flakes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,3 +43,11 @@ jobs:
 
     - name: Tests (Liquid mode, REST)
       run: cargo test --features liquid
+
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - run: nix build .
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 *.sublime*
 *~
 *.pyc
+result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50548a349632abb9a2007d431a302bf0401a786c91f809ff31765fba87e2397"
 dependencies = [
  "anyhow",
+ "bitcoincore-rpc",
+ "log",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "bitcoind"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09db6b30b527263d2e3a8768a2c9299763858cb84d01a9d63d174b9f515e1a32"
+dependencies = [
+ "anyhow",
  "bitcoin_hashes 0.13.0",
  "bitcoincore-rpc",
  "flate2",
@@ -623,7 +636,7 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "bitcoin 0.31.1",
- "bitcoind",
+ "bitcoind 0.35.1",
  "clap",
  "crossbeam-channel",
  "dirs",
@@ -679,7 +692,7 @@ dependencies = [
 [[package]]
 name = "electrumd"
 version = "0.1.0"
-source = "git+https://github.com/shesek/electrumd?rev=6eac0b7b1f2447472016e2c1473a6284f7f8648e#6eac0b7b1f2447472016e2c1473a6284f7f8648e"
+source = "git+https://github.com/shesek/electrumd?rev=996fe2a8e563bc1bde6bbc2e0c2a2f4421abcdbc#996fe2a8e563bc1bde6bbc2e0c2a2f4421abcdbc"
 dependencies = [
  "bitcoin_hashes 0.10.0",
  "home",
@@ -704,12 +717,12 @@ dependencies = [
 
 [[package]]
 name = "elementsd"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae67bd67005d700439d49468429ea4b4648f20fafe1192e528bda1b15bf164c"
+checksum = "f17022ca1a790518f66c46c40ab729cc275f8a009babad583972a946a851cadf"
 dependencies = [
  "bitcoin_hashes 0.12.0",
- "bitcoind",
+ "bitcoind 0.34.1",
  "flate2",
  "minreq",
  "tar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64-compat"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd00f3c09b5f21fb357abe32d29946eb8bb7a0862bae62c0b5e4a692acbbe73c"
+checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
  "bech32 0.10.0-beta",
  "bitcoin-internals",
@@ -291,7 +297,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "856ffbee2e492c23bca715d72ea34aae80d58400f2bda26a82015d6bc2ec3662"
 dependencies = [
- "bitcoin 0.31.1",
+ "bitcoin 0.31.2",
  "serde",
  "serde_json",
 ]
@@ -532,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -633,9 +639,9 @@ version = "0.4.1"
 dependencies = [
  "arraydeque",
  "arrayref",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
- "bitcoin 0.31.1",
+ "bitcoin 0.31.2",
  "bitcoind 0.35.1",
  "clap",
  "crossbeam-channel",
@@ -670,7 +676,7 @@ dependencies = [
  "time 0.3.34",
  "tiny_http",
  "tokio",
- "ureq 2.9.5",
+ "ureq 2.9.6",
  "url",
 ]
 
@@ -709,7 +715,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6b8388053196e6b2702a45418078a654680ce9e1fd91799f51f67a40118ff5"
 dependencies = [
- "bitcoin 0.31.1",
+ "bitcoin 0.31.2",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -952,29 +958,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "hoot"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df22a4d90f1b0e65fe3e0d6ee6a4608cc4d81f4b2eb3e670f44bb6bde711e452"
-dependencies = [
- "httparse",
- "log",
-]
-
-[[package]]
-name = "hootbin"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354e60868e49ea1a39c44b9562ad207c4259dc6eabf9863bf3b0f058c55cfdb2"
-dependencies = [
- "fastrand",
- "hoot",
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -1251,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lz4-sys"
@@ -1634,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -1962,18 +1945,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1982,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -2070,12 +2053,12 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2231,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2398,9 +2381,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "libc",
@@ -2520,12 +2503,11 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "2.9.5"
+version = "2.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b52731d03d6bb2fd18289d4028aee361d6c28d44977846793b994b13cdcc64d"
+checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
 dependencies = [
  "base64 0.21.7",
- "hootbin",
  "log",
  "once_cell",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ electrum-discovery = [ "electrum-client"]
 [dependencies]
 arraydeque = "0.5.1"
 arrayref = "0.3.6"
-base64 = "0.21.3"
+base64 = "0.22"
 bincode = "1.3.1"
 bitcoin = { version = "0.31", features = [ "serde" ] }
 clap = "2.33.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ electrum-client = { version = "0.8", optional = true }
 
 
 [dev-dependencies]
-bitcoind = { version = "0.34", features = [ "25_0" ] }
+bitcoind = { version = "0.35", features = [ "25_0" ] }
 elementsd = { version = "0.9", features = [ "22_1_1" ] }
 electrumd = { version = "0.1.0", features = [ "4_1_5" ] }
 ureq = { version = "2.9", default-features = false, features = [ "json" ] }
@@ -76,4 +76,4 @@ rev = "d3792352992a539afffbe11501d1aff9fd5b919d" # add-peer branch
 # not yet published on crates.io
 [patch.crates-io.electrumd]
 git = "https://github.com/shesek/electrumd"
-rev = "6eac0b7b1f2447472016e2c1473a6284f7f8648e"
+rev = "996fe2a8e563bc1bde6bbc2e0c2a2f4421abcdbc"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,106 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1711586303,
+        "narHash": "sha256-iZDHWTqQj6z6ccqTSEOPOxQ8KMFAemInUObN2R9vHSs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "a329cd00398379c62e76fc3b8d4ec2934260d636",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711523803,
+        "narHash": "sha256-UKcYiHWHQynzj6CN/vTcix4yd1eCu1uFdsuarupdCQQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2726f127c15a4cc9810843b96cad73c7eb39e443",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1711592024,
+        "narHash": "sha256-oD4OJ3TRmVrbAuKZWxElRCyCagNCDuhfw2exBmNOy48=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "aa858717377db2ed8ffd2d44147d907baee656e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,85 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+  };
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, crane }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+          rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+          craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+          src = craneLib.cleanCargoSource ./.; 
+
+          nativeBuildInputs = with pkgs; [ rustToolchain clang ]; # required only at build time
+          buildInputs = with pkgs; [ ]; # also required at runtime
+
+          commonArgs = {
+            inherit src buildInputs nativeBuildInputs;
+            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+            ELEMENTSD_SKIP_DOWNLOAD = true;
+            BITCOIND_SKIP_DOWNLOAD = true;
+            ELECTRUMD_SKIP_DOWNLOAD = true;
+          };
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          bin = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+
+            # TODO: do testing by providing executables via *_EXE env var for {bitcoin,elements,electrum}d
+            doCheck = false;
+          });
+          binLiquid = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+            cargoExtraArgs = "--features liquid";
+
+            # TODO: do testing by providing executables via *_EXE env var for {bitcoin,elements,electrum}d
+            doCheck = false;
+          });
+
+
+        in
+        with pkgs;
+        {
+          packages =
+            {
+              # that way we can build `bin` specifically,
+              # but it's also the default.
+              inherit bin;
+              default = bin;
+            };
+
+          apps."blockstream-electrs-liquid" = {
+            type = "app";
+            program = "${binLiquid}/bin/electrs";
+          };
+          apps."blockstream-electrs" = {
+            type = "app";
+            program = "${bin}/bin/electrs";
+          };
+
+
+          devShells.default = mkShell {
+            inputsFrom = [ bin ];
+          };
+        }
+      );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
 
           devShells.default = mkShell {
             inputsFrom = [ bin ];
+            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib"; # for rocksdb
           };
         }
       );

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.75.0"


### PR DESCRIPTION
By default runs the bitcoin version

```shell
$ nix run .
Config { log: StdErrLog { verbosity: Error, quiet: false, show_level: true, timestamp: Off, modules: [], writer: "stderr", color_choice: Auto, show_module_names: false }, network_type: Bitcoin, db_path: "./db/mainnet", daemon_dir: "/home/casatta/.bitcoin", blocks_dir: "/home/casatta/.bitcoin/blocks", daemon_rpc_addr: 127.0.0.1:8332, cookie: None, electrum_rpc_addr: 127.0.0.1:50001, http_addr: 127.0.0.1:3000, http_socket_file: None, monitoring_addr: 127.0.0.1:4224, jsonrpc_import: false, light_mode: false, address_search: false, index_unspendables: false, cors: None, precache_scripts: None, utxos_limit: 500, electrum_txs_limit: 500, electrum_banner: "Welcome to electrs-esplora 0.4.1", electrum_rpc_logging: None }
```

But it contains also a package with the liquid variant:

```shell
$ nix run .#blockstream-electrs-liquid -- --network liquid
Config { log: StdErrLog { verbosity: Error, quiet: false, show_level: true, timestamp: Off, modules: [], writer: "stderr", color_choice: Auto, show_module_names: false }, network_type: Liquid, db_path: "./db/liquid", daemon_dir: "/home/casatta/.bitcoin/liquidv1", blocks_dir: "/home/casatta/.bitcoin/liquidv1/blocks", daemon_rpc_addr: 127.0.0.1:7041, cookie: None, electrum_rpc_addr: 127.0.0.1:51000, http_addr: 127.0.0.1:3000, http_socket_file: None, monitoring_addr: 127.0.0.1:34224, jsonrpc_import: false, light_mode: false, address_search: false, index_unspendables: false, cors: None, precache_scripts: None, utxos_limit: 500, electrum_txs_limit: 500, electrum_banner: "Welcome to electrs-esplora 0.4.1", electrum_rpc_logging: None, parent_network: Bitcoin, asset_db_path: None }
```

on top of #79

replaces #78
