### PR TITLE
Speed up utxo API enpoint

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -17,9 +17,12 @@ use elements::{
     AssetId,
 };
 
-use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Arc, RwLock};
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    convert::TryInto,
+};
 
 use crate::chain::{
     BlockHash, BlockHeader, Network, OutPoint, Script, Transaction, TxOut, Txid, Value,
@@ -596,9 +599,13 @@ impl ChainQuery {
         let history_iter = self
             .history_iter_scan(b'H', scripthash, start_height)
             .map(TxHistoryRow::from_row)
-            .filter_map(|history| {
-                self.tx_confirming_block(&history.get_txid())
-                    .map(|b| (history, b))
+            .map(|history| {
+                let height = history.key.confirmed_height;
+                (
+                    history,
+                    self.blockid_by_height(height as usize)
+                        .expect("missing blockheader for valid utxo cache entry"),
+                )
             });
 
         let mut utxos = init_utxos;


### PR DESCRIPTION
1. Currenty we will join history db to get confirmed block meta for every funding transaction and spending transcation when iterate over all history transactions for specific address when getting utxos which will call history_db.get() every transaction. Thus slower the utxo API endpoint
2. After change we can only use `confirmed_height` to query block from in-memory indexed headers meta to speed up the process, which will significantly improve the utxo API endpoint performance