### PR TITLE
Support Testnet4 Network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +134,16 @@ name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
+]
 
 [[package]]
 name = "base64"
@@ -184,6 +200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,11 +254,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
  "bech32 0.10.0-beta",
- "bitcoin-internals",
+ "bitcoin-internals 0.2.0",
  "bitcoin_hashes 0.13.0",
- "hex-conservative",
+ "hex-conservative 0.1.1",
  "hex_lit",
  "secp256k1 0.28.2",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.32.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+dependencies = [
+ "base58ck",
+ "bech32 0.11.0",
+ "bitcoin-internals 0.3.0",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
+ "hex_lit",
+ "secp256k1 0.29.1",
  "serde",
 ]
 
@@ -250,6 +290,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
 name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +315,16 @@ name = "bitcoin-test-data"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c188654f9dce3bc6ce1bfa9c49777ad514bcad37e421b5f53e9d0ee10603f34"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "serde",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -285,8 +350,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
- "hex-conservative",
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
  "serde",
 ]
 
@@ -779,7 +855,8 @@ dependencies = [
  "arrayref",
  "base64 0.22.0",
  "bincode",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.5",
+ "bitcoin-io",
  "bitcoin-test-data",
  "bitcoind",
  "clap 2.34.0",
@@ -792,7 +869,7 @@ dependencies = [
  "elementsd",
  "error-chain",
  "glob",
- "hex-conservative",
+ "hex-conservative 0.2.1",
  "hyper",
  "hyperlocal",
  "itertools 0.12.1",
@@ -852,11 +929,12 @@ dependencies = [
 
 [[package]]
 name = "elements"
-version = "0.24.1"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6b8388053196e6b2702a45418078a654680ce9e1fd91799f51f67a40118ff5"
+checksum = "e8ab681914c4d96235d4c30d6a758f4aeb4eace26837f4995ca84bf7ea3189ea"
 dependencies = [
- "bitcoin 0.31.2",
+ "bech32 0.11.0",
+ "bitcoin 0.32.5",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -1110,6 +1188,15 @@ name = "hex-conservative"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hex_lit"
@@ -2151,6 +2238,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "bitcoin_hashes 0.13.0",
+ "rand 0.8.5",
+ "secp256k1-sys 0.10.1",
+ "serde",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,26 +2268,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1-zkp"
+name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e48ef9c98bfbcb98bd15693ffa19676cb3e29426b75eda8b73c05cdd7959f8"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-zkp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a44aed3002b5ae975f8624c5df3a949cfbf00479e18778b6058fcd213b76e3"
 dependencies = [
  "bitcoin-private",
  "rand 0.8.5",
- "secp256k1 0.28.2",
+ "secp256k1 0.29.1",
  "secp256k1-zkp-sys",
  "serde",
 ]
 
 [[package]]
 name = "secp256k1-zkp-sys"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ead52f43074bae2ddbd1e0e66e6b170135e76117f5ea9916f33d7bd0b36e29"
+checksum = "57f08b2d0b143a22e07f798ae4f0ab20d5590d7c68e0d090f2088a48a21d1654"
 dependencies = [
  "cc",
- "secp256k1-sys 0.9.2",
+ "secp256k1-sys 0.10.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,15 @@ arraydeque = "0.5.1"
 arrayref = "0.3.6"
 base64 = "0.22"
 bincode = "1.3.1"
-bitcoin = { version = "0.31", features = ["serde"] }
+bitcoin = { version = "0.32.5", features = [ "serde" ] }
+bitcoin-io = "0.1.2"
 clap = "2.33.3"
 crossbeam-channel = "0.5.0"
 dirs = "5.0.1"
-elements = { version = "0.24", features = ["serde"], optional = true }
+elements = { version = "0.25.1", features = ["serde"], optional = true }
 error-chain = "0.12.4"
 glob = "0.3"
-hex = { package = "hex-conservative", version = "0.1.1" }
+hex = { package = "hex-conservative", version = "0.2.1" }
 itertools = "0.12"
 lazy_static = "1.3.0"
 libc = "0.2.81"

--- a/src/bin/tx-fingerprint-stats.rs
+++ b/src/bin/tx-fingerprint-stats.rs
@@ -12,7 +12,7 @@ fn main() {
     use bitcoin::blockdata::script::ScriptBuf;
     use bitcoin::consensus::encode::deserialize;
     use electrs::{
-        chain::Transaction,
+        chain::{Transaction, TxOperations},
         config::Config,
         daemon::Daemon,
         metrics::Metrics,
@@ -62,7 +62,7 @@ fn main() {
         }
 
         let tx: Transaction = deserialize(&value).expect("failed to parse Transaction");
-        let txid = tx.txid();
+        let txid = TxOperations::txid(&tx);
 
         iter.next();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,19 +125,19 @@ impl Config {
             .arg(
                 Arg::with_name("electrum_rpc_addr")
                     .long("electrum-rpc-addr")
-                    .help("Electrum server JSONRPC 'addr:port' to listen on (default: '127.0.0.1:50001' for mainnet, '127.0.0.1:60001' for testnet and '127.0.0.1:60401' for regtest)")
+                    .help("Electrum server JSONRPC 'addr:port' to listen on (default: '127.0.0.1:50001' for mainnet, '127.0.0.1:60001' for testnet3 and '127.0.0.1:40001' for testnet4 and '127.0.0.1:60401' for regtest)")
                     .takes_value(true),
             )
             .arg(
                 Arg::with_name("http_addr")
                     .long("http-addr")
-                    .help("HTTP server 'addr:port' to listen on (default: '127.0.0.1:3000' for mainnet, '127.0.0.1:3001' for testnet and '127.0.0.1:3002' for regtest)")
+                    .help("HTTP server 'addr:port' to listen on (default: '127.0.0.1:3000' for mainnet, '127.0.0.1:3001' for testnet3 and '127.0.0.1:3004' for testnet4 and '127.0.0.1:3002' for regtest)")
                     .takes_value(true),
             )
             .arg(
                 Arg::with_name("daemon_rpc_addr")
                     .long("daemon-rpc-addr")
-                    .help("Bitcoin daemon JSONRPC 'addr:port' to connect (default: 127.0.0.1:8332 for mainnet, 127.0.0.1:18332 for testnet and 127.0.0.1:18443 for regtest)")
+                    .help("Bitcoin daemon JSONRPC 'addr:port' to connect (default: 127.0.0.1:8332 for mainnet, 127.0.0.1:18332 for testnet3 and 127.0.0.1:48332 for testnet4 and 127.0.0.1:18443 for regtest)")
                     .takes_value(true),
             )
             .arg(
@@ -149,7 +149,7 @@ impl Config {
             .arg(
                 Arg::with_name("monitoring_addr")
                     .long("monitoring-addr")
-                    .help("Prometheus monitoring 'addr:port' to listen on (default: 127.0.0.1:4224 for mainnet, 127.0.0.1:14224 for testnet and 127.0.0.1:24224 for regtest)")
+                    .help("Prometheus monitoring 'addr:port' to listen on (default: 127.0.0.1:4224 for mainnet, 127.0.0.1:14224 for testnet3 and 127.0.0.1:44224 for testnet4 and 127.0.0.1:24224 for regtest)")
                     .takes_value(true),
             )
             .arg(
@@ -282,6 +282,8 @@ impl Config {
             #[cfg(not(feature = "liquid"))]
             Network::Testnet => 18332,
             #[cfg(not(feature = "liquid"))]
+            Network::Testnet4 => 48332,
+            #[cfg(not(feature = "liquid"))]
             Network::Regtest => 18443,
             #[cfg(not(feature = "liquid"))]
             Network::Signet => 38332,
@@ -296,6 +298,8 @@ impl Config {
             Network::Bitcoin => 50001,
             #[cfg(not(feature = "liquid"))]
             Network::Testnet => 60001,
+            #[cfg(not(feature = "liquid"))]
+            Network::Testnet4 => 40001,
             #[cfg(not(feature = "liquid"))]
             Network::Regtest => 60401,
             #[cfg(not(feature = "liquid"))]
@@ -314,6 +318,8 @@ impl Config {
             #[cfg(not(feature = "liquid"))]
             Network::Testnet => 3001,
             #[cfg(not(feature = "liquid"))]
+            Network::Testnet4 => 3004,
+            #[cfg(not(feature = "liquid"))]
             Network::Regtest => 3002,
             #[cfg(not(feature = "liquid"))]
             Network::Signet => 3003,
@@ -330,6 +336,8 @@ impl Config {
             Network::Bitcoin => 4224,
             #[cfg(not(feature = "liquid"))]
             Network::Testnet => 14224,
+            #[cfg(not(feature = "liquid"))]
+            Network::Testnet4 => 44224,
             #[cfg(not(feature = "liquid"))]
             Network::Regtest => 24224,
             #[cfg(not(feature = "liquid"))]
@@ -491,6 +499,8 @@ pub fn get_network_subdir(network: Network) -> Option<&'static str> {
         Network::Bitcoin => None,
         #[cfg(not(feature = "liquid"))]
         Network::Testnet => Some("testnet3"),
+        #[cfg(not(feature = "liquid"))]
+        Network::Testnet4 => Some("testnet4"),
         #[cfg(not(feature = "liquid"))]
         Network::Regtest => Some("regtest"),
         #[cfg(not(feature = "liquid"))]

--- a/src/new_index/fetch.rs
+++ b/src/new_index/fetch.rs
@@ -9,7 +9,6 @@ use elements::encode::{deserialize, Decodable};
 
 use std::collections::HashMap;
 use std::fs;
-use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::thread;
@@ -201,7 +200,7 @@ fn blkfiles_parser(blobs: Fetcher<Vec<u8>>, magic: u32) -> Fetcher<Vec<SizedBloc
 }
 
 fn parse_blocks(blob: Vec<u8>, magic: u32) -> Result<Vec<SizedBlock>> {
-    let mut cursor = Cursor::new(&blob);
+    let mut cursor = cursor::Cursor::new(&blob);
     let mut slices = vec![];
     let max_pos = blob.len() as u64;
 
@@ -248,4 +247,104 @@ fn parse_blocks(blob: Vec<u8>, magic: u32) -> Result<Vec<SizedBlock>> {
             .map(|(slice, size)| (deserialize(slice).expect("failed to parse Block"), size))
             .collect()
     }))
+}
+
+mod cursor {
+    use std::convert::TryInto;
+
+    pub struct Cursor<T> {
+        inner: T,
+        pos: u64,
+    }
+
+    impl<T: AsRef<[u8]>> Cursor<T> {
+        /// Creates a `Cursor` by wrapping `inner`.
+        #[inline]
+        pub fn new(inner: T) -> Self {
+            Cursor { inner, pos: 0 }
+        }
+
+        /// Returns the position read up to thus far.
+        #[inline]
+        pub fn position(&self) -> u64 {
+            self.pos
+        }
+
+        /// Sets the position to `pos`.
+        #[inline]
+        pub fn set_position(&mut self, pos: u64) {
+            self.pos = pos;
+        }
+
+        /// Returns the inner buffer.
+        ///
+        /// This is the whole wrapped buffer, including the bytes already read.
+        #[inline]
+        #[allow(dead_code)]
+        pub fn into_inner(self) -> T {
+            self.inner
+        }
+    }
+
+    #[cfg(not(feature = "liquid"))]
+    impl<T: AsRef<[u8]>> bitcoin_io::Read for Cursor<T> {
+        #[inline]
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize, bitcoin_io::Error> {
+            let inner: &[u8] = self.inner.as_ref();
+            let start_pos = self.pos.try_into().unwrap_or(inner.len());
+            let read = core::cmp::min(inner.len().saturating_sub(start_pos), buf.len());
+            buf[..read].copy_from_slice(&inner[start_pos..start_pos + read]);
+            self.pos = self.pos.saturating_add(
+                read.try_into()
+                    .unwrap_or(u64::max_value() /* unreachable */),
+            );
+            Ok(read)
+        }
+    }
+
+    #[cfg(not(feature = "liquid"))]
+    impl<T: AsRef<[u8]>> bitcoin_io::BufRead for Cursor<T> {
+        #[inline]
+        fn fill_buf(&mut self) -> Result<&[u8], bitcoin_io::Error> {
+            let inner: &[u8] = self.inner.as_ref();
+            Ok(&inner[self.pos as usize..])
+        }
+
+        #[inline]
+        fn consume(&mut self, amount: usize) {
+            assert!(amount <= self.inner.as_ref().len());
+            self.pos += amount as u64;
+        }
+    }
+
+    #[cfg(feature = "liquid")]
+    impl<T: AsRef<[u8]>> std::io::Read for Cursor<T> {
+        #[inline]
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
+            let inner: &[u8] = self.inner.as_ref();
+            let start_pos = self.pos.try_into().unwrap_or(inner.len());
+            let read = core::cmp::min(inner.len().saturating_sub(start_pos), buf.len());
+            buf[..read].copy_from_slice(&inner[start_pos..start_pos + read]);
+            self.pos = self.pos.saturating_add(
+                read.try_into()
+                    .unwrap_or(u64::max_value() /* unreachable */),
+            );
+            Ok(read)
+        }
+    }
+
+    #[cfg(feature = "liquid")]
+    impl<T: AsRef<[u8]>> std::io::BufRead for Cursor<T> {
+        #[inline]
+        fn fill_buf(&mut self) -> Result<&[u8], std::io::Error> {
+            let inner: &[u8] = self.inner.as_ref();
+            Ok(&inner[self.pos as usize..])
+        }
+
+        #[inline]
+        fn consume(&mut self, amount: usize) {
+            assert!(amount <= self.inner.as_ref().len());
+            self.pos += amount as u64;
+        }
+    }
 }

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 use std::time::{Duration, Instant};
 
-use crate::chain::{Network, OutPoint, Transaction, TxOut, Txid};
+use crate::chain::{Network, OutPoint, Transaction, TxOperations, TxOut, Txid};
 use crate::config::Config;
 use crate::daemon::Daemon;
 use crate::errors::*;
@@ -133,7 +133,7 @@ impl Query {
     }
 
     pub fn lookup_tx_spends(&self, tx: Transaction) -> Vec<Option<SpendingInput>> {
-        let txid = tx.txid();
+        let txid = TxOperations::txid(&tx);
 
         tx.output
             .par_iter()

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1,6 +1,6 @@
 use crate::chain::{
     address, BlockHash, Network, OutPoint, Script, Sequence, Transaction, TxIn, TxMerkleNode,
-    TxOut, Txid,
+    TxOperations, TxOut, Txid,
 };
 use crate::config::Config;
 use crate::errors;
@@ -158,7 +158,7 @@ impl TransactionValue {
         let weight = weight.to_wu();
 
         TransactionValue {
-            txid: tx.txid(),
+            txid: TxOperations::txid(&tx),
             #[cfg(not(feature = "liquid"))]
             version: tx.version.0 as u32,
             #[cfg(feature = "liquid")]
@@ -319,7 +319,7 @@ impl TxOutValue {
             "v0_p2wsh"
         } else if script.is_p2tr() {
             "v1_p2tr"
-        } else if script.is_provably_unspendable() {
+        } else if script.is_op_return() {
             "provably_unspendable"
         } else {
             "unknown"
@@ -1264,12 +1264,7 @@ impl From<hex::HexToArrayError> for HttpError {
         HttpError::from("Invalid hex string".to_string())
     }
 }
-impl From<bitcoin::address::Error> for HttpError {
-    fn from(_e: bitcoin::address::Error) -> Self {
-        //HttpError::from(e.description().to_string())
-        HttpError::from("Invalid Bitcoin address".to_string())
-    }
-}
+
 impl From<errors::Error> for HttpError {
     fn from(e: errors::Error) -> Self {
         warn!("errors::Error: {:?}", e);

--- a/src/util/electrum_merkle.rs
+++ b/src/util/electrum_merkle.rs
@@ -1,7 +1,7 @@
 use crate::chain::{BlockHash, Txid};
 use crate::errors::*;
 use crate::new_index::ChainQuery;
-use bitcoin::hashes::{sha256d::Hash as Sha256dHash, Hash};
+use bitcoin::hashes::sha256d::Hash as Sha256dHash;
 
 pub fn get_tx_merkle_proof(
     chain: &ChainQuery,
@@ -80,7 +80,7 @@ pub fn get_id_from_pos(
 
 fn merklize(left: Sha256dHash, right: Sha256dHash) -> Sha256dHash {
     let data = [&left[..], &right[..]].concat();
-    Sha256dHash::hash(&data)
+    bitcoin::hashes::Hash::hash(&data)
 }
 
 fn create_merkle_branch_and_root(

--- a/src/util/script.rs
+++ b/src/util/script.rs
@@ -27,7 +27,8 @@ pub trait ScriptToAddr {
 #[cfg(not(feature = "liquid"))]
 impl ScriptToAddr for bitcoin::Script {
     fn to_address_str(&self, network: Network) -> Option<String> {
-        bitcoin::Address::from_script(self, network.into())
+        let bnetwork = bitcoin::Network::from(network);
+        bitcoin::Address::from_script(self, bnetwork)
             .map(|s| s.to_string())
             .ok()
     }

--- a/src/util/transaction.rs
+++ b/src/util/transaction.rs
@@ -70,9 +70,9 @@ pub fn has_prevout(txin: &TxIn) -> bool {
 
 pub fn is_spendable(txout: &TxOut) -> bool {
     #[cfg(not(feature = "liquid"))]
-    return !txout.script_pubkey.is_provably_unspendable();
+    return !txout.script_pubkey.is_op_return();
     #[cfg(feature = "liquid")]
-    return !txout.is_fee() && !txout.script_pubkey.is_provably_unspendable();
+    return !txout.is_fee() && !txout.script_pubkey.is_op_return();
 }
 
 pub fn extract_tx_prevouts<'a>(


### PR DESCRIPTION
### Support for `testnet4` Block Data Indexing Based on Latest [`rust-bitcoin`](https://github.com/rust-bitcoin/rust-bitcoin/pull/2945)

During the development phase, I deployed a `testnet4` full node to test this feature, and everything worked as expected.

### Changes:

- **Implementation of `testnet4` Support**: This feature is based on the latest `rust-bitcoin`. Although the relevant PR has not yet been merged into [`bitcoin Core`](https://github.com/bitcoin/bitcoin/pull/29775), and thus [`rust-bitcoin`](https://github.com/rust-bitcoin/rust-bitcoin/pull/2945) has not been merged either, the code is stable and functional.

- **API Updates**: Updated several API calls that were flagged as deprecated by `rust-bitcoin`.

- **New Cursor for Block parse**: Implemented a new cursor for block parse due to the removal of some necessary APIs in the updated `rust-bitcoin`.

### Ask for advice:

After implementing these changes, everything functions correctly with the default feature set. However, when enabling the `liquid` feature, issues arise because it relies on `elements`, which is currently incompatible with the latest `rust-bitcoin`. I would appreciate any insights or suggestions on how to resolve this compatibility issue.

---

Thank you for your time and assistance.