### PR TITLE
Nix tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 [[package]]
 name = "electrumd"
 version = "0.1.0"
-source = "git+https://github.com/shesek/electrumd?rev=996fe2a8e563bc1bde6bbc2e0c2a2f4421abcdbc#996fe2a8e563bc1bde6bbc2e0c2a2f4421abcdbc"
+source = "git+https://github.com/shesek/electrumd?rev=b35d9db285d932cb3c2296beab65e571a2506349#b35d9db285d932cb3c2296beab65e571a2506349"
 dependencies = [
  "bitcoin_hashes 0.10.0",
  "home",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,22 +316,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "0.34.1"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50548a349632abb9a2007d431a302bf0401a786c91f809ff31765fba87e2397"
-dependencies = [
- "anyhow",
- "bitcoincore-rpc",
- "log",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "bitcoind"
-version = "0.35.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09db6b30b527263d2e3a8768a2c9299763858cb84d01a9d63d174b9f515e1a32"
+checksum = "2542fac51d8cd8fce6109f4a3ffd1acfdaa3394c36d4a8207af15b8b0540e2fc"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.13.0",
@@ -751,7 +738,7 @@ dependencies = [
  "bincode",
  "bitcoin 0.31.2",
  "bitcoin-test-data",
- "bitcoind 0.35.1",
+ "bitcoind",
  "clap 2.34.0",
  "criterion",
  "crossbeam-channel",
@@ -833,12 +820,12 @@ dependencies = [
 
 [[package]]
 name = "elementsd"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17022ca1a790518f66c46c40ab729cc275f8a009babad583972a946a851cadf"
+checksum = "19b08013ae0b60e4a3ac9d126e230338dec55575ddf7811aeaebb096f7c3abbf"
 dependencies = [
  "bitcoin_hashes 0.12.0",
- "bitcoind 0.34.1",
+ "bitcoind",
  "flate2",
  "minreq",
  "tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,9 @@ electrum-client = { version = "0.8", optional = true }
 
 
 [dev-dependencies]
-bitcoind = { version = "0.35", features = ["25_0"] }
-elementsd = { version = "0.9", features = ["22_1_1"] }
-electrumd = { version = "0.1.0", features = ["4_1_5"] }
+bitcoind = { version = "0.34.3", features = ["25_0"] }
+elementsd = { version = "0.9.2", features = ["22_1_1"] }
+electrumd = { version = "0.1.0", features = ["4_5_4"] }
 ureq = { version = "2.9", default-features = false, features = ["json"] }
 tempfile = "3.10"
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,4 +85,4 @@ rev = "d3792352992a539afffbe11501d1aff9fd5b919d"            # add-peer branch
 # not yet published on crates.io
 [patch.crates-io.electrumd]
 git = "https://github.com/shesek/electrumd"
-rev = "996fe2a8e563bc1bde6bbc2e0c2a2f4421abcdbc"
+rev = "b35d9db285d932cb3c2296beab65e571a2506349"

--- a/flake.nix
+++ b/flake.nix
@@ -36,16 +36,22 @@
           nativeBuildInputs = with pkgs; [ rustToolchain clang ]; # required only at build time
           buildInputs = with pkgs; [ ]; # also required at runtime
 
-          envVars = {
-            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
-            ELEMENTSD_SKIP_DOWNLOAD = true;
-            BITCOIND_SKIP_DOWNLOAD = true;
-            ELECTRUMD_SKIP_DOWNLOAD = true;
+          envVars =
+            {
+              LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+              ELEMENTSD_SKIP_DOWNLOAD = true;
+              BITCOIND_SKIP_DOWNLOAD = true;
+              ELECTRUMD_SKIP_DOWNLOAD = true;
 
-            # link rocksdb dynamically
-            ROCKSDB_INCLUDE_DIR = "${pkgs.rocksdb}/include";
-            ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
-          };
+              # link rocksdb dynamically
+              ROCKSDB_INCLUDE_DIR = "${pkgs.rocksdb}/include";
+              ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
+
+              # for integration testing
+              BITCOIND_EXE = "${pkgs.bitcoind}/bin/bitcoind";
+              ELEMENTSD_EXE = "${pkgs.elementsd}/bin/elementsd";
+              ELECTRUMD_EXE = "${pkgs.electrum}/bin/electrum";
+            };
 
           commonArgs = {
             inherit src buildInputs nativeBuildInputs;
@@ -54,16 +60,10 @@
           cargoArtifacts = craneLib.buildDepsOnly commonArgs;
           bin = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;
-
-            # TODO: do testing by providing executables via *_EXE env var for {bitcoin,elements,electrum}d
-            doCheck = false;
           });
           binLiquid = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;
             cargoExtraArgs = "--features liquid";
-
-            # TODO: do testing by providing executables via *_EXE env var for {bitcoin,elements,electrum}d
-            doCheck = false;
           });
 
         in

--- a/tests/electrum.rs
+++ b/tests/electrum.rs
@@ -125,7 +125,7 @@ fn test_electrum() -> Result<()> {
         )?]),
     )?;
     notify_wallet();
-    assert_balance(0.3, -0.161);
+    assert_balance(0.139, 0.0);
 
     tester.mine()?;
     notify_wallet();


### PR DESCRIPTION
Now on nix env we provide the env vars of the executables needed for
integration testing, so we can enable tests.

To be coherent with the electrum nix version used, upgrade also the
autodownloaded one.

Note we have to change a test assertion, it seems electrum behaviour
changed, upgrading balances before confirmation.