### PR TITLE
Introduce benching and improve `add_blocks` by 45%

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
+name = "bitcoin-test-data"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c188654f9dce3bc6ce1bfa9c49777ad514bcad37e421b5f53e9d0ee10603f34"
+
+[[package]]
 name = "bitcoin_hashes"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +456,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,9 +513,30 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "strsim",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "bitflags 1.3.2",
+ "clap_lex",
+ "indexmap",
+ "textwrap 0.16.1",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -537,6 +603,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap 3.2.25",
+ "criterion-plot",
+ "itertools 0.10.5",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +671,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -642,8 +750,10 @@ dependencies = [
  "base64 0.22.0",
  "bincode",
  "bitcoin 0.31.2",
+ "bitcoin-test-data",
  "bitcoind 0.35.1",
- "clap",
+ "clap 2.34.0",
+ "criterion",
  "crossbeam-channel",
  "dirs",
  "electrum-client",
@@ -655,7 +765,7 @@ dependencies = [
  "hex-conservative",
  "hyper",
  "hyperlocal",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "libc",
  "log",
@@ -910,6 +1020,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1201,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1228,15 @@ dependencies = [
  "hermit-abi 0.3.5",
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1350,10 +1495,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "page_size"
@@ -1460,6 +1617,34 @@ name = "pkg-config"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+
+[[package]]
+name = "plotters"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1838,6 +2023,15 @@ name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2243,6 +2437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+
+[[package]]
 name = "thiserror"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,6 +2562,16 @@ dependencies = [
  "chunked_transfer",
  "httpdate",
  "log",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2543,6 +2753,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,20 @@ readme = "README.md"
 edition = "2018"
 
 [features]
-liquid = [ "elements" ]
-electrum-discovery = [ "electrum-client"]
+liquid = ["elements"]
+electrum-discovery = ["electrum-client"]
+bench = []
 
 [dependencies]
 arraydeque = "0.5.1"
 arrayref = "0.3.6"
 base64 = "0.22"
 bincode = "1.3.1"
-bitcoin = { version = "0.31", features = [ "serde" ] }
+bitcoin = { version = "0.31", features = ["serde"] }
 clap = "2.33.3"
 crossbeam-channel = "0.5.0"
 dirs = "5.0.1"
-elements = { version = "0.24", features = [ "serde" ], optional = true }
+elements = { version = "0.24", features = ["serde"], optional = true }
 error-chain = "0.12.4"
 glob = "0.3"
 hex = { package = "hex-conservative", version = "0.1.1" }
@@ -58,11 +59,19 @@ electrum-client = { version = "0.8", optional = true }
 
 
 [dev-dependencies]
-bitcoind = { version = "0.35", features = [ "25_0" ] }
-elementsd = { version = "0.9", features = [ "22_1_1" ] }
-electrumd = { version = "0.1.0", features = [ "4_1_5" ] }
-ureq = { version = "2.9", default-features = false, features = [ "json" ] }
+bitcoind = { version = "0.35", features = ["25_0"] }
+elementsd = { version = "0.9", features = ["22_1_1"] }
+electrumd = { version = "0.1.0", features = ["4_1_5"] }
+ureq = { version = "2.9", default-features = false, features = ["json"] }
 tempfile = "3.10"
+criterion = { version = "0.4", features = ["html_reports"] }
+bitcoin-test-data = { version = "*" }
+
+[[bench]]
+name = "benches"
+harness = false
+required-features = ["bench"]
+
 
 [profile.release]
 lto = true
@@ -71,7 +80,7 @@ codegen-units = 1
 
 [patch.crates-io.electrum-client]
 git = "https://github.com/Blockstream/rust-electrum-client"
-rev = "d3792352992a539afffbe11501d1aff9fd5b919d" # add-peer branch
+rev = "d3792352992a539afffbe11501d1aff9fd5b919d"            # add-peer branch
 
 # not yet published on crates.io
 [patch.crates-io.electrumd]

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,0 +1,17 @@
+use bitcoin::{consensus::Decodable, Block};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use electrs::new_index::schema::bench::*;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("add_blocks", |b| {
+        let block_bytes = bitcoin_test_data::blocks::mainnet_702861();
+        let block = Block::consensus_decode(&mut &block_bytes[..]).unwrap();
+        let data = Data::new(block);
+        // TODO use iter_batched to avoid measuring cloning inputs
+
+        b.iter(move || black_box(add_blocks(&data)))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/new_index/fetch.rs
+++ b/src/new_index/fetch.rs
@@ -37,6 +37,7 @@ pub fn start_fetcher(
     fetcher(daemon, new_headers)
 }
 
+#[derive(Clone)]
 pub struct BlockEntry {
     pub block: Block,
     pub entry: HeaderEntry,

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -978,8 +978,8 @@ fn add_blocks(block_entries: &[BlockEntry], iconfig: &IndexerConfig) -> Vec<DBRo
             let mut rows = vec![];
             let blockhash = full_hash(&b.entry.hash()[..]);
             let txids: Vec<Txid> = b.block.txdata.iter().map(|tx| tx.txid()).collect();
-            for tx in &b.block.txdata {
-                add_transaction(tx, blockhash, &mut rows, iconfig);
+            for (tx, txid) in b.block.txdata.iter().zip(txids.iter()) {
+                add_transaction(*txid, tx, blockhash, &mut rows, iconfig);
             }
 
             if !iconfig.light_mode {
@@ -996,6 +996,7 @@ fn add_blocks(block_entries: &[BlockEntry], iconfig: &IndexerConfig) -> Vec<DBRo
 }
 
 fn add_transaction(
+    txid: Txid,
     tx: &Transaction,
     blockhash: FullHash,
     rows: &mut Vec<DBRow>,
@@ -1007,7 +1008,7 @@ fn add_transaction(
         rows.push(TxRow::new(tx).into_row());
     }
 
-    let txid = full_hash(&tx.txid()[..]);
+    let txid = full_hash(&txid[..]);
     for (txo_index, txo) in tx.output.iter().enumerate() {
         if is_spendable(txo) {
             rows.push(TxOutRow::new(&txid, txo_index, txo).into_row());

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -1002,7 +1002,7 @@ fn add_transaction(
     rows: &mut Vec<DBRow>,
     iconfig: &IndexerConfig,
 ) {
-    rows.push(TxConfRow::new(tx, blockhash).into_row());
+    rows.push(TxConfRow::new(txid, blockhash).into_row());
 
     if !iconfig.light_mode {
         rows.push(TxRow::new(tx).into_row());
@@ -1216,8 +1216,8 @@ struct TxConfRow {
 }
 
 impl TxConfRow {
-    fn new(txn: &Transaction, blockhash: FullHash) -> TxConfRow {
-        let txid = full_hash(&txn.txid()[..]);
+    fn new(txid: Txid, blockhash: FullHash) -> TxConfRow {
+        let txid = full_hash(&txid[..]);
         TxConfRow {
             key: TxConfKey {
                 code: b'C',

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -1005,7 +1005,7 @@ fn add_transaction(
     rows.push(TxConfRow::new(txid, blockhash).into_row());
 
     if !iconfig.light_mode {
-        rows.push(TxRow::new(tx).into_row());
+        rows.push(TxRow::new(txid, tx).into_row());
     }
 
     let txid = full_hash(&txid[..]);
@@ -1183,8 +1183,8 @@ struct TxRow {
 }
 
 impl TxRow {
-    fn new(txn: &Transaction) -> TxRow {
-        let txid = full_hash(&txn.txid()[..]);
+    fn new(txid: Txid, txn: &Transaction) -> TxRow {
+        let txid = full_hash(&txid[..]);
         TxRow {
             key: TxRowKey { code: b'T', txid },
             value: serialize(txn),

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -1646,3 +1646,46 @@ impl GetAmountVal for confidential::Value {
         self
     }
 }
+
+// This is needed to bench private functions
+#[cfg(feature = "bench")]
+pub mod bench {
+    use crate::new_index::schema::IndexerConfig;
+    use crate::new_index::BlockEntry;
+    use crate::new_index::DBRow;
+    use crate::util::HeaderEntry;
+    use bitcoin::Block;
+
+    pub struct Data {
+        block_entry: BlockEntry,
+        iconfig: IndexerConfig,
+    }
+
+    impl Data {
+        pub fn new(block: Block) -> Data {
+            let iconfig = IndexerConfig {
+                light_mode: false,
+                address_search: false,
+                index_unspendables: false,
+                network: crate::chain::Network::Regtest,
+            };
+            let height = 702861;
+            let hash = block.block_hash();
+            let header = block.header.clone();
+            let block_entry = BlockEntry {
+                block,
+                entry: HeaderEntry::new(height, hash, header),
+                size: 0u32, // wrong but not needed for benching
+            };
+
+            Data {
+                block_entry,
+                iconfig,
+            }
+        }
+    }
+
+    pub fn add_blocks(data: &Data) -> Vec<DBRow> {
+        super::add_blocks(&[data.block_entry.clone()], &data.iconfig)
+    }
+}

--- a/src/util/block.rs
+++ b/src/util/block.rs
@@ -43,6 +43,14 @@ pub struct HeaderEntry {
 }
 
 impl HeaderEntry {
+    #[cfg(feature = "bench")]
+    pub fn new(height: usize, hash: BlockHash, header: BlockHeader) -> Self {
+        Self {
+            height,
+            hash,
+            header,
+        }
+    }
     pub fn hash(&self) -> &BlockHash {
         &self.hash
     }


### PR DESCRIPTION
This introduce benching via criterion so that performance changes can be measured.

Criterion is used so that nightly is not required to run benchmarks and also has a nice change report.

The bench feature is introduced to expose to benching private functions, otherwise unreachable from the `benches` dir.

After setting up benchmark for the `add_blocks` 3 commits avoiding to recompute txids in various places gave a cumulative performance improvement of 45%

```
add_blocks              time:   [3.0339 ms 3.0457 ms 3.0579 ms]
                        change: [-45.830% -45.556% -45.277%] (p = 0.00 < 0.05)
                        Performance has improved.
```