### PR TITLE
Integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,10 +39,10 @@ jobs:
       run: cargo check
 
     - name: Tests (Bitcoin mode, REST+Electrum)
-      run: cargo test
+      run: RUST_LOG=debug cargo test
 
     - name: Tests (Liquid mode, REST)
-      run: cargo test --features liquid
+      run: RUST_LOG=debug cargo test --features liquid
 
   nix:
     runs-on: ubuntu-latest

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,6 +1,8 @@
+use std::str::FromStr;
 use std::sync::{Arc, Once, RwLock};
 use std::{env, net};
 
+use log::LevelFilter;
 use stderrlog::StdErrLog;
 use tempfile::TempDir;
 
@@ -53,7 +55,7 @@ impl TestRunner {
             #[cfg(feature = "liquid")]
             node_conf.args.push("-anyonecanspendaremine=1");
 
-            node_conf.view_stdout = true;
+            node_conf.view_stdout = std::env::var_os("RUST_LOG").is_some();
         }
 
         // Setup node
@@ -310,7 +312,11 @@ fn generate(
 fn init_log() -> StdErrLog {
     static ONCE: Once = Once::new();
     let mut log = stderrlog::new();
-    log.verbosity(4);
+    match std::env::var("RUST_LOG") {
+        Ok(e) => log.verbosity(LevelFilter::from_str(&e).unwrap_or(LevelFilter::Off)),
+        Err(_) => log.verbosity(0),
+    };
+
     // log.timestamp(stderrlog::Timestamp::Millisecond        );
     ONCE.call_once(|| log.init().expect("logging initialization failed"));
     log

--- a/tests/electrum.rs
+++ b/tests/electrum.rs
@@ -21,7 +21,11 @@ fn test_electrum() -> Result<()> {
     // Spawn an headless Electrum wallet RPC daemon, connected to Electrs
     let mut electrum_wallet_conf = electrumd::Conf::default();
     let server_arg = format!("{}:t", electrum_addr.to_string());
-    electrum_wallet_conf.args = vec!["-v", "--server", &server_arg];
+    electrum_wallet_conf.args = if std::env::var_os("RUST_LOG").is_some() {
+        vec!["-v", "--server", &server_arg]
+    } else {
+        vec!["--server", &server_arg]
+    };
     electrum_wallet_conf.view_stdout = true;
     let electrum_wallet = ElectrumD::with_conf(electrumd::exe_path()?, &electrum_wallet_conf)?;
 


### PR DESCRIPTION
With this by default `cargo test` will not print any logs

by doing `RUST_LOG=debug cargo test` instead, there is the same logging than before this MR