### PR TITLE
Batching with array

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,8 +45,12 @@ jobs:
     - name: Tests (Bitcoin mode, REST+Electrum)
       run: RUST_LOG=debug cargo test
 
+    - name: Test test_electrum_raw
+      run: RUST_LOG=debug cargo test -- --include-ignored test_electrum_raw
+
     - name: Tests (Liquid mode, REST)
       run: RUST_LOG=debug cargo test --features liquid
+
 
   nix:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - new-index
+  pull_request: {}
 
 jobs:
   test:

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -555,7 +555,8 @@ impl Connection {
             match msg {
                 Message::Request(line) => {
                     let cmd: Value = from_str(&line).chain_err(|| "invalid JSON format")?;
-                    self.handle_value(cmd, &empty_params, start_time)?;
+                    let reply = self.handle_value(cmd, &empty_params, start_time)?;
+                    self.send_values(&[reply])?
                 }
                 Message::PeriodicUpdate => {
                     let values = self
@@ -573,7 +574,7 @@ impl Connection {
         cmd: Value,
         empty_params: &Value,
         start_time: Instant,
-    ) -> Result<()> {
+    ) -> Result<Value> {
         Ok(
             match (
                 cmd.get("method"),
@@ -608,7 +609,7 @@ impl Connection {
                         })
                     );
 
-                    self.send_values(&[reply])?
+                    reply
                 }
                 _ => {
                     bail!("invalid command: {}", cmd)

--- a/tests/electrum.rs
+++ b/tests/electrum.rs
@@ -141,7 +141,7 @@ fn test_electrum() -> Result<()> {
     Ok(())
 }
 
-/// Test the Electrum RPC server using an headless Electrum wallet
+/// Test the Electrum RPC server using a raw TCP socket
 /// This only runs on Bitcoin (non-Liquid) mode.
 #[cfg_attr(not(feature = "liquid"), test)]
 #[cfg_attr(feature = "liquid", allow(dead_code))]

--- a/tests/electrum.rs
+++ b/tests/electrum.rs
@@ -145,6 +145,7 @@ fn test_electrum() -> Result<()> {
 /// This only runs on Bitcoin (non-Liquid) mode.
 #[cfg_attr(not(feature = "liquid"), test)]
 #[cfg_attr(feature = "liquid", allow(dead_code))]
+#[ignore = "must be launched singularly, otherwise conflict with the other server"]
 fn test_electrum_raw() {
     // Spawn an Electrs Electrum RPC server
     let (_electrum_server, electrum_addr, mut _tester) = common::init_electrum_tester().unwrap();

--- a/tests/electrum.rs
+++ b/tests/electrum.rs
@@ -156,6 +156,12 @@ fn test_electrum_raw() {
     let s = write_and_read(&mut stream, write);
     let expected = "{\"id\":0,\"jsonrpc\":\"2.0\",\"result\":[\"electrs-esplora 0.4.1\",\"1.4\"]}";
     assert_eq!(s, expected);
+
+    let write = "[{\"jsonrpc\": \"2.0\", \"method\": \"server.version\", \"id\": 0}]";
+    let s = write_and_read(&mut stream, write);
+    let expected =
+        "[{\"id\":0,\"jsonrpc\":\"2.0\",\"result\":[\"electrs-esplora 0.4.1\",\"1.4\"]}]";
+    assert_eq!(s, expected);
 }
 
 fn write_and_read(stream: &mut TcpStream, write: &str) -> String {


### PR DESCRIPTION
Currently electrs support batching by separating requests via new lines, however, other impls support it also via json array  as explained in the cited issue. This add support for batching requests via json array

close https://github.com/Blockstream/esplora/issues/516