### PR TITLE
chore: time 0.3.34 -> 0.3.36 to support latest rustc stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
  "stderrlog",
  "sysconf",
  "tempfile",
- "time 0.3.34",
+ "time 0.3.36",
  "tiny_http",
  "tokio",
  "ureq 2.9.6",
@@ -2487,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -2497,7 +2497,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.17",
+ "time-macros 0.2.18",
 ]
 
 [[package]]
@@ -2518,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3093,7 +3093,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1 0.10.6",
- "time 0.3.34",
+ "time 0.3.36",
  "zstd",
 ]
 


### PR DESCRIPTION
The most recent stable compilers (1.79+) fail with "type annotations needed" when compiling the `time` crate with version <= 0.3.35:

```bash
$ cargo +1.80.1 check
# ...
error[E0282]: type annotations needed for `Box<_>`
  --> /Users/phlip9/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.34/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
help: consider giving `items` an explicit type, where the placeholders `_` are specified
   |
83 |     let items: Box<_> = format_items
   |              ++++++++

    Checking hyperlocal v0.8.0
For more information about this error, try `rustc --explain E0282`.
error: could not compile `time` (lib) due to 1 previous error
```

This diff updates the time crate v0.3.34 -> v0.3.36 so we can compile with the latest stable compiler.

You can also reproduce this update with:

```bash
$ cargo +1.80.1 update -p time@0.3.34 --precise 0.3.36
    Updating crates.io index
    Updating time v0.3.34 -> v0.3.36
    Updating time-macros v0.2.17 -> v0.2.18
```