### PR TITLE
Tx cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +48,12 @@ checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -288,6 +306,15 @@ dependencies = [
  "bitcoin-internals",
  "hex-conservative",
  "serde",
+]
+
+[[package]]
+name = "bitcoin_slices"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8041a1be831c809ada090db2e3bd1469c65b72321bb2f31d7f56261eefc8321"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -738,6 +765,7 @@ dependencies = [
  "bincode",
  "bitcoin 0.31.2",
  "bitcoin-test-data",
+ "bitcoin_slices",
  "bitcoind",
  "clap 2.34.0",
  "criterion",
@@ -1023,6 +1051,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,7 +1232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3075,6 +3113,26 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["bitcoin", "electrum", "server", "index", "database"]
 documentation = "https://docs.rs/electrs/"
 readme = "README.md"
 edition = "2018"
+default-run = "electrs"
 
 [features]
 liquid = ["elements"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ tokio = { version = "1", features = ["sync", "macros"] }
 
 # optional dependencies for electrum-discovery
 electrum-client = { version = "0.8", optional = true }
+bitcoin_slices = { version = "0.8.0", features = ["slice_cache"] }
 
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,12 @@ pub struct Config {
     /// Tx cache size in megabytes
     pub tx_cache_size: usize,
 
+    /// Enable compaction during initial sync
+    ///
+    /// By default compaction is off until initial sync is finished for performance reasons,
+    /// however, this requires much more disk space.
+    pub initial_sync_compaction: bool,
+
     #[cfg(feature = "liquid")]
     pub parent_network: BNetwork,
     #[cfg(feature = "liquid")]
@@ -199,6 +205,10 @@ impl Config {
                     .long("tx-cache-size")
                     .help("The amount of MB for a in-memory cache for transactions.")
                     .default_value("1000")
+            ).arg(
+                Arg::with_name("initial_sync_compaction")
+                    .long("initial-sync-compaction")
+                    .help("Perform compaction during initial sync (slower but less disk space required)")
             );
 
         #[cfg(unix)]
@@ -412,6 +422,7 @@ impl Config {
             cors: m.value_of("cors").map(|s| s.to_string()),
             precache_scripts: m.value_of("precache_scripts").map(|s| s.to_string()),
             tx_cache_size: value_t_or_exit!(m, "tx_cache_size", usize),
+            initial_sync_compaction: m.is_present("initial_sync_compaction"),
 
             #[cfg(feature = "liquid")]
             parent_network,

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,9 @@ pub struct Config {
     pub electrum_banner: String,
     pub electrum_rpc_logging: Option<RpcLogging>,
 
+    /// Tx cache size in megabytes
+    pub tx_cache_size: usize,
+
     #[cfg(feature = "liquid")]
     pub parent_network: BNetwork,
     #[cfg(feature = "liquid")]
@@ -191,6 +194,11 @@ impl Config {
                     .long("electrum-rpc-logging")
                     .help(&rpc_logging_help)
                     .takes_value(true),
+            ).arg(
+                Arg::with_name("tx_cache_size")
+                    .long("tx-cache-size")
+                    .help("The amount of MB for a in-memory cache for transactions.")
+                    .default_value("1000")
             );
 
         #[cfg(unix)]
@@ -403,6 +411,7 @@ impl Config {
             index_unspendables: m.is_present("index_unspendables"),
             cors: m.value_of("cors").map(|s| s.to_string()),
             precache_scripts: m.value_of("precache_scripts").map(|s| s.to_string()),
+            tx_cache_size: value_t_or_exit!(m, "tx_cache_size", usize),
 
             #[cfg(feature = "liquid")]
             parent_network,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -424,7 +424,7 @@ impl Daemon {
         loop {
             match self.handle_request_batch(method, params_list) {
                 Err(Error(ErrorKind::Connection(msg), _)) => {
-                    warn!("reconnecting to bitcoind: {}", msg);
+                    warn!("reconnecting to bitcoind: {msg}\nmethod was:{method}\nwith_params:{params_list:?}");
                     self.signal.wait(Duration::from_secs(3), false)?;
                     let mut conn = self.conn.lock().unwrap();
                     *conn = conn.reconnect()?;

--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -90,7 +90,7 @@ impl DB {
         db_opts.set_compression_type(rocksdb::DBCompressionType::Snappy);
         db_opts.set_target_file_size_base(1_073_741_824);
         db_opts.set_write_buffer_size(256 << 20);
-        db_opts.set_disable_auto_compactions(true); // for initial bulk load
+        db_opts.set_disable_auto_compactions(!config.initial_sync_compaction); // for initial bulk load
 
         // db_opts.set_advise_random_on_open(???);
         db_opts.set_compaction_readahead_size(1 << 20);

--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -154,7 +154,7 @@ impl DB {
     }
 
     pub fn write(&self, mut rows: Vec<DBRow>, flush: DBFlush) {
-        debug!(
+        log::trace!(
             "writing {} rows to {:?}, flush={:?}",
             rows.len(),
             self.db,

--- a/src/new_index/fetch.rs
+++ b/src/new_index/fetch.rs
@@ -99,6 +99,7 @@ fn bitcoind_fetcher(
                 sender
                     .send(block_entries)
                     .expect("failed to send fetched blocks");
+                log::debug!("last fetch {:?}", entries.last());
             }
         }),
     ))

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -370,7 +370,7 @@ impl ChainQuery {
                 HistogramOpts::new("query_duration", "Index query duration (in seconds)"),
                 &["name"],
             ),
-            txs_cache: Mutex::new(SliceCache::new(1_000_000_000)),
+            txs_cache: Mutex::new(SliceCache::new(config.tx_cache_size << 20)),
             cache_hit: metrics.counter(MetricOpts::new("tx_cache_hit", "Tx cache Hit")),
             cache_miss: metrics.counter(MetricOpts::new("tx_cache_miss", "Tx cache Miss")),
         }

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -877,11 +877,17 @@ impl ChainQuery {
             self.store.txstore_db.get(&TxRow::key(&txid[..]))
         };
         if let Some(result) = result.as_ref() {
-            if let Ok(mut cache) = self.txs_cache.lock() {
-                let _ = cache.insert(txid.clone(), result);
-            }
+            self.add_txs_to_cache(&[(*txid, result)]);
         }
         result
+    }
+
+    pub fn add_txs_to_cache<T: AsRef<[u8]>>(&self, txs: &[(Txid, T)]) {
+        if let Ok(mut cache) = self.txs_cache.lock() {
+            for (txid, tx) in txs {
+                let _ = cache.insert(*txid, &tx.as_ref());
+            }
+        }
     }
 
     pub fn lookup_txo(&self, outpoint: &OutPoint) -> Option<TxOut> {

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -882,6 +882,18 @@ impl ChainQuery {
         result
     }
 
+    pub fn txs_cache_miss(&self, txids: &[Txid]) -> Vec<Txid> {
+        let mut result = vec![];
+        if let Ok(cache) = self.txs_cache.lock() {
+            for txid in txids {
+                if !cache.contains(txid) {
+                    result.push(*txid);
+                }
+            }
+        }
+        result
+    }
+
     pub fn add_txs_to_cache<T: AsRef<[u8]>>(&self, txs: &[(Txid, T)]) {
         if let Ok(mut cache) = self.txs_cache.lock() {
             for (txid, tx) in txs {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -113,6 +113,8 @@ impl TestRunner {
             asset_db_path: None, // XXX
             #[cfg(feature = "liquid")]
             parent_network: bitcoin::Network::Regtest,
+            tx_cache_size: 100,
+            initial_sync_compaction: false,
             //#[cfg(feature = "electrum-discovery")]
             //electrum_public_hosts: Option<crate::electrum::ServerHosts>,
             //#[cfg(feature = "electrum-discovery")]


### PR DESCRIPTION
Introduce a tx cache for the tx cache lookup.

The same crate for the cache has been introduced by romanz electrs, it's main advantages are that is a contiguous memory region capped in size.

The hypothesis is that with a big enough cache it's possible to run a public instance in lightmode, without duplicating tx data which is already present in the bitcoin node.