### PR TITLE
Use `electrs` as default run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["bitcoin", "electrum", "server", "index", "database"]
 documentation = "https://docs.rs/electrs/"
 readme = "README.md"
 edition = "2018"
+default-run = "electrs"
 
 [features]
 liquid = ["elements"]


### PR DESCRIPTION
By doing so simply `cargo run` launch the server, while before was required `cargo run --bin electrs`