### PR TITLE
bitcoind: support v28.0's new default "blk*.dat" xor'ing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,5 @@
 #![recursion_limit = "1024"]
 
-// See https://github.com/romanz/electrs/issues/193 & https://github.com/rust-rocksdb/rust-rocksdb/issues/327
-#[cfg(not(feature = "oldcpu"))]
-extern crate rocksdb;
-#[cfg(feature = "oldcpu")]
-extern crate rocksdb_oldcpu as rocksdb;
-
 #[macro_use]
 extern crate clap;
 #[macro_use]

--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -163,10 +163,7 @@ impl DB {
         rows.sort_unstable_by(|a, b| a.key.cmp(&b.key));
         let mut batch = rocksdb::WriteBatch::default();
         for row in rows {
-            #[cfg(not(feature = "oldcpu"))]
             batch.put(&row.key, &row.value);
-            #[cfg(feature = "oldcpu")]
-            batch.put(&row.key, &row.value).unwrap();
         }
         let do_flush = match flush {
             DBFlush::Enable => true,


### PR DESCRIPTION
bitcoind v28.0 added a new "feature" that, by default, xors all "blk*.dat" files on-disk with a random 8-byte key, saved to "xor.dat" on-disk. See: <https://github.com/bitcoin/bitcoin/pull/28052>.

This diff adds support by first (1) reading the "xor.dat" key and then (2) xor'ing all "blk*.dat" files with it as we read them. If there is no "xor.dat" (old bitcoind version or disabled with the "-blocksxor=0" flag), then we don't do any xor'ing.

Compiling with latest stable also revealed that the "oldcpu" feature doesn't exist anymore, so I also removed those dead `#[cfg(feature = "oldcpu")]` blocks.

You can easily test against v28.0 if you have `nix` installed:

```rust
$ nix build -L github:NixOS/nixpkgs/nixos-unstable#bitcoind
$ readlink result
/nix/store/33cbyzrgi9f2s7v4rakn5yfsscqxr59x-bitcoind-28.0

$ BITCOIND_SKIP_DOWNLOAD=1 \
    BITCOIND_EXE=/nix/store/33cbyzrgi9f2s7v4rakn5yfsscqxr59x-bitcoind-28.0/bin/bitcoind \
    cargo test -- --nocapture
```

Running `test_electrum` without this patch:

```rust
$ BITCOIND_SKIP_DOWNLOAD=1 \
    BITCOIND_EXE=/nix/store/33cbyzrgi9f2s7v4rakn5yfsscqxr59x-bitcoind-28.0/bin/bitcoind \
    cargo test --test electrum -- --nocapture

   Compiling electrs v0.4.1 (/home/phlip9/dev/blockstream-electrs)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 13.77s
     Running tests/electrum.rs (target/debug/deps/electrum-0f37414ffe1e8f36)

running 1 test
thread 'blkfiles_fetcher' panicked at src/new_index/fetch.rs:146:17:
failed to index 102 blocks from blk*.dat files
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'test_electrum' panicked at src/new_index/fetch.rs:66:28:
fetcher thread panicked: Any { .. }
test test_electrum ... FAILED

failures:

failures:
    test_electrum

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.36s

error: test failed, to rerun pass `--test electrum`

```