### PR TITLE
feat: support testnet4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ arraydeque = "0.5.1"
 arrayref = "0.3.6"
 base64 = "0.22"
 bincode = "1.3.1"
-bitcoin = { version = "0.32", features = ["serde"] }
+bitcoin = { version = "0.32.4", features = ["serde"] }
 clap = "2.33.3"
 crossbeam-channel = "0.5.0"
 dirs = "5.0.1"

--- a/electrs_macros/src/lib.rs
+++ b/electrs_macros/src/lib.rs
@@ -1,6 +1,5 @@
 use proc_macro::TokenStream;
 
-
 #[proc_macro_attribute]
 #[cfg(feature = "otlp-tracing")]
 pub fn trace(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -29,6 +29,8 @@ pub enum Network {
     #[cfg(not(feature = "liquid"))]
     Testnet,
     #[cfg(not(feature = "liquid"))]
+    Testnet4,
+    #[cfg(not(feature = "liquid"))]
     Regtest,
     #[cfg(not(feature = "liquid"))]
     Signet,
@@ -97,6 +99,7 @@ impl Network {
         return vec![
             "mainnet".to_string(),
             "testnet".to_string(),
+            "testnet4".to_string(),
             "regtest".to_string(),
             "signet".to_string(),
         ];
@@ -123,6 +126,8 @@ pub fn bitcoin_genesis_hash(network: BNetwork) -> bitcoin::BlockHash {
             genesis_block(BNetwork::Bitcoin).block_hash();
         static ref TESTNET_GENESIS: bitcoin::BlockHash =
             genesis_block(BNetwork::Testnet).block_hash();
+        static ref TESTNET4_GENESIS: bitcoin::BlockHash =
+            genesis_block(BNetwork::Testnet4).block_hash();
         static ref REGTEST_GENESIS: bitcoin::BlockHash =
             genesis_block(BNetwork::Regtest).block_hash();
         static ref SIGNET_GENESIS: bitcoin::BlockHash =
@@ -131,6 +136,7 @@ pub fn bitcoin_genesis_hash(network: BNetwork) -> bitcoin::BlockHash {
     match network {
         BNetwork::Bitcoin => *BITCOIN_GENESIS,
         BNetwork::Testnet => *TESTNET_GENESIS,
+        BNetwork::Testnet4 => *TESTNET4_GENESIS,
         BNetwork::Regtest => *REGTEST_GENESIS,
         BNetwork::Signet => *SIGNET_GENESIS,
         _ => panic!("unknown network {:?}", network),
@@ -165,6 +171,8 @@ impl From<&str> for Network {
             #[cfg(not(feature = "liquid"))]
             "testnet" => Network::Testnet,
             #[cfg(not(feature = "liquid"))]
+            "testnet4" => Network::Testnet4,
+            #[cfg(not(feature = "liquid"))]
             "regtest" => Network::Regtest,
             #[cfg(not(feature = "liquid"))]
             "signet" => Network::Signet,
@@ -187,6 +195,7 @@ impl From<Network> for BNetwork {
         match network {
             Network::Bitcoin => BNetwork::Bitcoin,
             Network::Testnet => BNetwork::Testnet,
+            Network::Testnet4 => BNetwork::Testnet4,
             Network::Regtest => BNetwork::Regtest,
             Network::Signet => BNetwork::Signet,
         }
@@ -199,6 +208,7 @@ impl From<BNetwork> for Network {
         match network {
             BNetwork::Bitcoin => Network::Bitcoin,
             BNetwork::Testnet => Network::Testnet,
+            BNetwork::Testnet4 => Network::Testnet4,
             BNetwork::Regtest => Network::Regtest,
             BNetwork::Signet => Network::Signet,
             _ => panic!("unknown network {:?}", network),

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,19 +125,19 @@ impl Config {
             .arg(
                 Arg::with_name("electrum_rpc_addr")
                     .long("electrum-rpc-addr")
-                    .help("Electrum server JSONRPC 'addr:port' to listen on (default: '127.0.0.1:50001' for mainnet, '127.0.0.1:60001' for testnet and '127.0.0.1:60401' for regtest)")
+                    .help("Electrum server JSONRPC 'addr:port' to listen on (default: '127.0.0.1:50001' for mainnet, '127.0.0.1:60001' for testnet3, '127.0.0.1:40001' for testnet4 and '127.0.0.1:60401' for regtest)")
                     .takes_value(true),
             )
             .arg(
                 Arg::with_name("http_addr")
                     .long("http-addr")
-                    .help("HTTP server 'addr:port' to listen on (default: '127.0.0.1:3000' for mainnet, '127.0.0.1:3001' for testnet and '127.0.0.1:3002' for regtest)")
+                    .help("HTTP server 'addr:port' to listen on (default: '127.0.0.1:3000' for mainnet, '127.0.0.1:3001' for testnet3 and '127.0.0.1:3004' for testnet4 and '127.0.0.1:3002' for regtest)")
                     .takes_value(true),
             )
             .arg(
                 Arg::with_name("daemon_rpc_addr")
                     .long("daemon-rpc-addr")
-                    .help("Bitcoin daemon JSONRPC 'addr:port' to connect (default: 127.0.0.1:8332 for mainnet, 127.0.0.1:18332 for testnet and 127.0.0.1:18443 for regtest)")
+                    .help("Bitcoin daemon JSONRPC 'addr:port' to connect (default: 127.0.0.1:8332 for mainnet, 127.0.0.1:18332 for testnet3 and 127.0.0.1:48332 for testnet4 and 127.0.0.1:18443 for regtest)")
                     .takes_value(true),
             )
             .arg(
@@ -149,7 +149,7 @@ impl Config {
             .arg(
                 Arg::with_name("monitoring_addr")
                     .long("monitoring-addr")
-                    .help("Prometheus monitoring 'addr:port' to listen on (default: 127.0.0.1:4224 for mainnet, 127.0.0.1:14224 for testnet and 127.0.0.1:24224 for regtest)")
+                    .help("Prometheus monitoring 'addr:port' to listen on (default: 127.0.0.1:4224 for mainnet, 127.0.0.1:14224 for testnet3 and 127.0.0.1:44224 for testnet4 and 127.0.0.1:24224 for regtest)")
                     .takes_value(true),
             )
             .arg(
@@ -282,6 +282,8 @@ impl Config {
             #[cfg(not(feature = "liquid"))]
             Network::Testnet => 18332,
             #[cfg(not(feature = "liquid"))]
+            Network::Testnet4 => 48332,
+            #[cfg(not(feature = "liquid"))]
             Network::Regtest => 18443,
             #[cfg(not(feature = "liquid"))]
             Network::Signet => 38332,
@@ -296,6 +298,8 @@ impl Config {
             Network::Bitcoin => 50001,
             #[cfg(not(feature = "liquid"))]
             Network::Testnet => 60001,
+            #[cfg(not(feature = "liquid"))]
+            Network::Testnet4 => 40001,
             #[cfg(not(feature = "liquid"))]
             Network::Regtest => 60401,
             #[cfg(not(feature = "liquid"))]
@@ -314,6 +318,8 @@ impl Config {
             #[cfg(not(feature = "liquid"))]
             Network::Testnet => 3001,
             #[cfg(not(feature = "liquid"))]
+            Network::Testnet4 => 3004,
+            #[cfg(not(feature = "liquid"))]
             Network::Regtest => 3002,
             #[cfg(not(feature = "liquid"))]
             Network::Signet => 3003,
@@ -330,6 +336,8 @@ impl Config {
             Network::Bitcoin => 4224,
             #[cfg(not(feature = "liquid"))]
             Network::Testnet => 14224,
+            #[cfg(not(feature = "liquid"))]
+            Network::Testnet4 => 44224,
             #[cfg(not(feature = "liquid"))]
             Network::Regtest => 24224,
             #[cfg(not(feature = "liquid"))]
@@ -492,6 +500,8 @@ pub fn get_network_subdir(network: Network) -> Option<&'static str> {
         Network::Bitcoin => None,
         #[cfg(not(feature = "liquid"))]
         Network::Testnet => Some("testnet3"),
+        #[cfg(not(feature = "liquid"))]
+        Network::Testnet4 => Some("testnet4"),
         #[cfg(not(feature = "liquid"))]
         Network::Regtest => Some("regtest"),
         #[cfg(not(feature = "liquid"))]

--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -3,6 +3,7 @@ use itertools::{Either, Itertools};
 
 #[cfg(not(feature = "liquid"))]
 use bitcoin::consensus::encode::serialize;
+use electrs_macros::trace;
 #[cfg(feature = "liquid")]
 use elements::{encode::serialize, AssetId};
 
@@ -11,7 +12,6 @@ use std::iter::FromIterator;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
-use electrs_macros::trace;
 use crate::chain::{deserialize, BlockHash, Network, OutPoint, Transaction, TxOut, Txid};
 use crate::config::Config;
 use crate::daemon::Daemon;
@@ -516,7 +516,12 @@ impl Mempool {
         daemon: &Daemon,
         tip: &BlockHash,
     ) -> Result<bool> {
-        let _timer = mempool.read().unwrap().latency.with_label_values(&["update"]).start_timer();
+        let _timer = mempool
+            .read()
+            .unwrap()
+            .latency
+            .with_label_values(&["update"])
+            .start_timer();
 
         // Continuously attempt to fetch mempool transactions until we're able to get them in full
         let mut fetched_txs = HashMap::<Txid, Transaction>::new();
@@ -554,9 +559,18 @@ impl Mempool {
             {
                 let mempool = mempool.read().unwrap();
 
-                mempool.count.with_label_values(&["all_txs"]).set(all_txids.len() as f64);
-                mempool.count.with_label_values(&["fetched_txs"]).set((indexed_txids.len() + fetched_txs.len()) as f64);
-                mempool.count.with_label_values(&["missing_txs"]).set(new_txids.len() as f64);
+                mempool
+                    .count
+                    .with_label_values(&["all_txs"])
+                    .set(all_txids.len() as f64);
+                mempool
+                    .count
+                    .with_label_values(&["fetched_txs"])
+                    .set((indexed_txids.len() + fetched_txs.len()) as f64);
+                mempool
+                    .count
+                    .with_label_values(&["missing_txs"])
+                    .set(new_txids.len() as f64);
             }
 
             let new_txs = daemon.gettransactions_available(&new_txids)?;

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1,4 +1,3 @@
-
 use crate::chain::{
     address, BlockHash, Network, OutPoint, Script, Sequence, Transaction, TxIn, TxMerkleNode,
     TxOut, Txid,
@@ -6,13 +5,13 @@ use crate::chain::{
 use crate::config::Config;
 use crate::errors;
 use crate::new_index::{compute_script_hash, Query, SpendingInput, Utxo};
+#[cfg(feature = "liquid")]
+use crate::util::optional_value_for_newer_blocks;
 use crate::util::{
     create_socket, electrum_merkle, extract_tx_prevouts, get_innerscripts, get_tx_fee, has_prevout,
     is_coinbase, BlockHeaderMeta, BlockId, FullHash, ScriptToAddr, ScriptToAsm, TransactionStatus,
     DEFAULT_BLOCKHASH,
 };
-#[cfg(feature = "liquid")]
-use crate::util::optional_value_for_newer_blocks;
 #[cfg(not(feature = "liquid"))]
 use bitcoin::consensus::encode;
 
@@ -186,14 +185,18 @@ impl TransactionValue {
             status: Some(TransactionStatus::from(blockid)),
 
             #[cfg(feature = "liquid")]
-            discount_vsize: optional_value_for_newer_blocks(blockid,
-                                                            START_OF_LIQUID_DISCOUNT_CT_POLICY,
-                                                            tx.discount_vsize()),
+            discount_vsize: optional_value_for_newer_blocks(
+                blockid,
+                START_OF_LIQUID_DISCOUNT_CT_POLICY,
+                tx.discount_vsize(),
+            ),
 
             #[cfg(feature = "liquid")]
-            discount_weight: optional_value_for_newer_blocks(blockid,
-                                                             START_OF_LIQUID_DISCOUNT_CT_POLICY,
-                                                             tx.discount_weight()),
+            discount_weight: optional_value_for_newer_blocks(
+                blockid,
+                START_OF_LIQUID_DISCOUNT_CT_POLICY,
+                tx.discount_weight(),
+            ),
         }
     }
 }

--- a/src/util/transaction.rs
+++ b/src/util/transaction.rs
@@ -45,11 +45,12 @@ impl From<Option<BlockId>> for TransactionStatus {
     }
 }
 
-
 #[cfg(feature = "liquid")]
-pub fn optional_value_for_newer_blocks(block_id: Option<BlockId>,
-                                       check_time: u32,
-                                       value: usize) -> Option<usize> {
+pub fn optional_value_for_newer_blocks(
+    block_id: Option<BlockId>,
+    check_time: u32,
+    value: usize,
+) -> Option<usize> {
     match block_id {
         // use the provided value only if it was after the "activation" time
         Some(b) if b.time >= check_time => Some(value),
@@ -132,13 +133,12 @@ where
     s.end()
 }
 
-
 #[cfg(all(test, feature = "liquid"))]
 mod test {
+    use super::optional_value_for_newer_blocks;
+    use crate::util::BlockId;
     use bitcoin::hashes::Hash;
     use elements::BlockHash;
-    use crate::util::BlockId;
-    use super::optional_value_for_newer_blocks;
 
     #[test]
     fn opt_value_newer_block() {
@@ -149,20 +149,58 @@ mod test {
 
         // unconfirmed block should include the value
         let block_id = None;
-        assert_eq!(optional_value_for_newer_blocks(block_id, check_time, value), Some(value));
+        assert_eq!(
+            optional_value_for_newer_blocks(block_id, check_time, value),
+            Some(value)
+        );
 
         // block time before check_time should NOT include the value
-        let block_id = Some(BlockId{ height, hash, time: 0 });
-        assert_eq!(optional_value_for_newer_blocks(block_id, check_time, value), None);
-        let block_id = Some(BlockId{ height, hash, time: 31 });
-        assert_eq!(optional_value_for_newer_blocks(block_id, check_time, value), None);
+        let block_id = Some(BlockId {
+            height,
+            hash,
+            time: 0,
+        });
+        assert_eq!(
+            optional_value_for_newer_blocks(block_id, check_time, value),
+            None
+        );
+        let block_id = Some(BlockId {
+            height,
+            hash,
+            time: 31,
+        });
+        assert_eq!(
+            optional_value_for_newer_blocks(block_id, check_time, value),
+            None
+        );
 
         // block time on or after check_time should include the value
-        let block_id = Some(BlockId{ height, hash, time: 32 });
-        assert_eq!(optional_value_for_newer_blocks(block_id, check_time, value), Some(value));
-        let block_id = Some(BlockId{ height, hash, time: 33 });
-        assert_eq!(optional_value_for_newer_blocks(block_id, check_time, value), Some(value));
-        let block_id = Some(BlockId{ height, hash, time: 333 });
-        assert_eq!(optional_value_for_newer_blocks(block_id, check_time, value), Some(value));
+        let block_id = Some(BlockId {
+            height,
+            hash,
+            time: 32,
+        });
+        assert_eq!(
+            optional_value_for_newer_blocks(block_id, check_time, value),
+            Some(value)
+        );
+        let block_id = Some(BlockId {
+            height,
+            hash,
+            time: 33,
+        });
+        assert_eq!(
+            optional_value_for_newer_blocks(block_id, check_time, value),
+            Some(value)
+        );
+        let block_id = Some(BlockId {
+            height,
+            hash,
+            time: 333,
+        });
+        assert_eq!(
+            optional_value_for_newer_blocks(block_id, check_time, value),
+            Some(value)
+        );
     }
 }


### PR DESCRIPTION
I have rebased the code from https://github.com/Blockstream/electrs/pull/91 since that has merge conflicts and it seems it's dormant since 2 months. I also removed some changes that I think were not necessary (probably there to update rust-bitcoin, which has been already done on the updated tip) and formatted the code with the latest Rust stable version. Moreover I would have renamed the existing `Testnet` variant to `Testnet3`, but this is not a decision I should take so let me know if this looks good to you or if you want me to make some changes. 