### PR TITLE
Update usage.md

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -7,7 +7,7 @@ and [latest Electrum wallet](https://electrum.org/#download) (3.2+).
 Also, install the following packages (on Debian):
 ```bash
 $ sudo apt update
-$ sudo apt install clang cmake  # for building 'rust-rocksdb'
+$ sudo apt install clang cmake build-essential  # for building 'rust-rocksdb'
 ```
 
 ## Build


### PR DESCRIPTION
For compilation of electrs to work in Ubuntu 20.04 build-essential package needs to be installed.