### PR TITLE
Rpc log ip anonymisation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1639,7 +1639,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1753,7 +1753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2620,7 +2620,7 @@ dependencies = [
  "errno 0.3.10",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3170,7 +3170,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3927,7 +3927,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ arraydeque = "0.5.1"
 arrayref = "0.3.6"
 base64 = "0.22"
 bincode = "1.3.1"
-bitcoin = { version = "0.32.4", features = ["serde"] }
+bitcoin = { version = "0.32.4", features = ["serde", "rand"] }
 clap = "2.33.3"
 crossbeam-channel = "0.5.0"
 dirs = "5.0.1"

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -27,6 +27,7 @@ use electrs::{
     rest,
     signal::Waiter,
 };
+use electrs::config::RpcLogging;
 
 pub struct TestRunner {
     config: Arc<Config>,
@@ -38,6 +39,7 @@ pub struct TestRunner {
     daemon: Arc<Daemon>,
     mempool: Arc<RwLock<Mempool>>,
     metrics: Metrics,
+    salt_rwlock: Arc<RwLock<String>>,
 }
 
 impl TestRunner {
@@ -108,7 +110,7 @@ impl TestRunner {
             utxos_limit: 100,
             electrum_txs_limit: 100,
             electrum_banner: "".into(),
-            electrum_rpc_logging: None,
+            rpc_logging: RpcLogging::default(),
             zmq_addr: None,
 
             #[cfg(feature = "liquid")]
@@ -179,6 +181,8 @@ impl TestRunner {
             None, // TODO
         ));
 
+        let salt_rwlock = Arc::new(RwLock::new(String::from("foobar")));
+
         Ok(TestRunner {
             config,
             node,
@@ -188,6 +192,7 @@ impl TestRunner {
             daemon,
             mempool,
             metrics,
+            salt_rwlock,
         })
     }
 
@@ -280,6 +285,7 @@ pub fn init_electrum_tester() -> Result<(ElectrumRPC, net::SocketAddr, TestRunne
         Arc::clone(&tester.config),
         Arc::clone(&tester.query),
         &tester.metrics,
+        Arc::clone(&tester.salt_rwlock),
     );
     log::info!(
         "Electrum server running on {}",


### PR DESCRIPTION
Introduces mechanism for IP anonymisation in RPC log. It's turned on by providing `--electrum-rpc-logging anonymised` parameter. Possible set of parameters and a result of executing client request:
```
echo '{"jsonrpc":"2.0","id":18,"method":"blockchain.scripthash.get_history","params":["6b63eef944d982701eb2d0dbb8ee900f42d8e79fe3d1ea473602c0edc87c34f6"]}' | nc localhost 50001
```
is following:
```
--electrum-rpc-logging with-params anonymised
{"event":"rpc request","id":18,"method":"blockchain.scripthash.get_history","params":["6b63eef944d982701eb2d0dbb8ee900f42d8e79fe3d1ea473602c0edc87c34f6"],"source":{"ip":"249e448ff0b4bb71b5ac2472066343f932c047992135c414d4c1012ec3d7e56b","port":51913}}

--electrum-rpc-logging no-params anonymised
{"event":"rpc request","id":18,"method":"blockchain.scripthash.get_history","params":null,"source":{"ip":"46aa0e33aed5391dd3f7b350ac3e7dbb99ab7d3bc7137479d68ee6baef8a04ce","port":51944}}

--electrum-rpc-logging anonymised
{"event":"rpc request","id":18,"method":"blockchain.scripthash.get_history","params":null,"source":{"ip":"d817f783df6de6ae961133b9ba44e01a5aa072a98a547248bc0d67fb89384e8c","port":51969}}

--electrum-rpc-logging with-params
{"event":"rpc request","id":18,"method":"blockchain.scripthash.get_history","params":["6b63eef944d982701eb2d0dbb8ee900f42d8e79fe3d1ea473602c0edc87c34f6"],"source":{"ip":"127.0.0.1","port":51987}}

--electrum-rpc-logging no-params
{"event":"rpc request","id":18,"method":"blockchain.scripthash.get_history","params":null,"source":{"ip":"127.0.0.1","port":52029}}
```

Anonymisation is using SHA256 hashing with a random salt rotated every 24 hours or electrs restart.