### PR TITLE
only set discount CT attributes on tx newer than CT start date

### DIFF
--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -60,6 +60,8 @@ pub struct TxOverview {
     vsize: u64,
     #[cfg(not(feature = "liquid"))]
     value: u64,
+    #[cfg(feature = "liquid")]
+    discount_vsize: u64,
 }
 
 impl Mempool {
@@ -366,6 +368,8 @@ impl Mempool {
                     .values()
                     .map(|prevout| prevout.value.to_sat())
                     .sum(),
+                #[cfg(feature = "liquid")]
+                discount_vsize: tx.discount_vsize() as u64,
             });
 
             self.feeinfo.insert(txid, feeinfo);

--- a/src/util/block.rs
+++ b/src/util/block.rs
@@ -20,7 +20,7 @@ lazy_static! {
             .unwrap();
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub struct BlockId {
     pub height: usize,
     pub hash: BlockHash,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,6 +16,9 @@ pub use self::transaction::{
     serialize_outpoint, TransactionStatus, TxInput,
 };
 
+#[cfg(feature = "liquid")]
+pub use self::transaction::optional_value_for_newer_blocks;
+
 use std::collections::HashMap;
 use std::sync::mpsc::{channel, sync_channel, Receiver, Sender, SyncSender};
 use std::thread;


### PR DESCRIPTION
- discount CT for liquid was enabled as policy on December 13, 2024; it doesn't make sense to add it to txes from before that date

- add discount_vsize to TxOverview struct