### PR TITLE
Fix for CI issue related to rand being not re-exported by bitcoin crate

### DIFF
--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -10,7 +10,7 @@ use std::{env, process, thread};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use bitcoin::hex::DisplayHex;
-use bitcoin::secp256k1::rand;
+use bitcoin::secp256k1::rand::{thread_rng, RngCore};
 use electrs::{
     config::Config,
     daemon::Daemon,
@@ -161,7 +161,8 @@ fn run_server(config: Arc<Config>, salt_rwlock: Arc<RwLock<String>>) -> Result<(
 }
 
 fn generate_salt() -> String {
-    let random_bytes: [u8; 32] = rand::random();
+    let mut random_bytes = [0u8; 32];
+    thread_rng().fill_bytes(&mut random_bytes);
     random_bytes.to_lower_hex_string()
 }
 


### PR DESCRIPTION
A try to fix CI error (the issue doesn't reproduce on my host):

```
#13 69.51 warning: unused import: `electrum_client::Error as ElectrumError`
#13 69.51  --> src/electrum/client.rs:6:9
#13 69.51   |
#13 69.51 6 | pub use electrum_client::Error as ElectrumError;
#13 69.51   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#13 69.51   |
#13 69.51   = note: `#[warn(unused_imports)]` on by default
#13 69.51 
#13 70.47 warning: field `added_by` is never read
#13 70.47   --> src/electrum/discovery.rs:83:5
#13 70.47    |
#13 70.47 78 | struct HealthCheck {
#13 70.47    |        ----------- field in this struct
#13 70.47 ...
#13 70.47 83 |     added_by: Option<IpAddr>,
#13 70.47    |     ^^^^^^^^
#13 70.47    |
#13 70.47    = note: `HealthCheck` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
#13 70.47    = note: `#[warn(dead_code)]` on by default
#13 70.47 
#13 89.92 warning: `electrs` (lib) generated 2 warnings (run `cargo fix --lib -p electrs` to apply 1 suggestion)
#13 89.99 error[E0425]: cannot find function `random` in crate `rand`
#13 89.99    --> src/bin/electrs.rs:164:40
#13 89.99     |
#13 89.99 164 |     let random_bytes: [u8; 32] = rand::random();
#13 89.99     |                                        ^^^^^^ not found in `rand`
#13 89.99     |
#13 89.99 note: found an item that was configured out
#13 89.99    --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rand-0.8.5/src/lib.rs:183:8
#13 89.99     |
#13 89.99 183 | pub fn random<T>() -> T
#13 89.99     |        ^^^^^^
#13 89.99 
#13 90.00 warning: unused import: `bitcoin::hex::DisplayHex`
#13 90.00   --> src/bin/electrs.rs:12:5
#13 90.00    |
#13 90.00 12 | use bitcoin::hex::DisplayHex;
#13 90.00    |     ^^^^^^^^^^^^^^^^^^^^^^^^
#13 90.00    |
#13 90.00    = note: `#[warn(unused_imports)]` on by default
#13 90.00 
#13 90.00 For more information about this error, try `rustc --explain E0425`.
#13 90.01 warning: `electrs` (bin "electrs") generated 1 warning
#13 90.01 error: could not compile `electrs` (bin "electrs") due to previous error; 1 warning emitted
#13 90.01 warning: build failed, waiting for other jobs to finish...
#13 114.2 error: failed to compile `electrs v0.4.1 (/app/electrs)`
```