### PR TITLE
Fix for cargo install fail.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "page_size",
  "prometheus",
+ "rand 0.9.1",
  "rayon",
  "rocksdb",
  "rust-crypto",
@@ -2363,8 +2364,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2375,6 +2386,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2399,6 +2420,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ arraydeque = "0.5.1"
 arrayref = "0.3.6"
 base64 = "0.22"
 bincode = "1.3.1"
-bitcoin = { version = "0.32.4", features = ["serde", "rand"] }
+bitcoin = { version = "0.32.4", features = ["serde"] }
 clap = "2.33.3"
 crossbeam-channel = "0.5.0"
 dirs = "5.0.1"
@@ -70,6 +70,7 @@ opentelemetry-otlp = { version = "0.13.0", default-features = false, features = 
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt"], optional = true }
 opentelemetry-semantic-conventions = { version = "0.12.0", optional = true }
 tracing = { version = "0.1.40", default-features = false, features = ["attributes"], optional = true }
+rand = "0.9.1"
 
 # optional dependencies for electrum-discovery
 electrum-client = { version = "0.8", optional = true }

--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -10,7 +10,7 @@ use std::{env, process, thread};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use bitcoin::hex::DisplayHex;
-use bitcoin::secp256k1::rand;
+use rand::{rng, RngCore};
 use electrs::{
     config::Config,
     daemon::Daemon,
@@ -161,7 +161,8 @@ fn run_server(config: Arc<Config>, salt_rwlock: Arc<RwLock<String>>) -> Result<(
 }
 
 fn generate_salt() -> String {
-    let random_bytes: [u8; 32] = rand::random();
+    let mut random_bytes = [0u8; 32];
+    rng().fill_bytes(&mut random_bytes);
     random_bytes.to_lower_hex_string()
 }
 


### PR DESCRIPTION
Fix for `cargo install` fail. `random` function was not re-exported by bitcoin::secp256k1::rand even though rand feature was enabled in bitcoin crate and resulted in following error:

```
#13 69.51 warning: unused import: `electrum_client::Error as ElectrumError`
#13 69.51  --> src/electrum/client.rs:6:9
#13 69.51   |
#13 69.51 6 | pub use electrum_client::Error as ElectrumError;
#13 69.51   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#13 69.51   |
#13 69.51   = note: `#[warn(unused_imports)]` on by default
#13 69.51 
#13 70.47 warning: field `added_by` is never read
#13 70.47   --> src/electrum/discovery.rs:83:5
#13 70.47    |
#13 70.47 78 | struct HealthCheck {
#13 70.47    |        ----------- field in this struct
#13 70.47 ...
#13 70.47 83 |     added_by: Option<IpAddr>,
#13 70.47    |     ^^^^^^^^
#13 70.47    |
#13 70.47    = note: `HealthCheck` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
#13 70.47    = note: `#[warn(dead_code)]` on by default
#13 70.47 
#13 89.92 warning: `electrs` (lib) generated 2 warnings (run `cargo fix --lib -p electrs` to apply 1 suggestion)
#13 89.99 error[E0425]: cannot find function `random` in crate `rand`
#13 89.99    --> src/bin/electrs.rs:164:40
#13 89.99     |
#13 89.99 164 |     let random_bytes: [u8; 32] = rand::random();
#13 89.99     |                                        ^^^^^^ not found in `rand`
#13 89.99     |
#13 89.99 note: found an item that was configured out
#13 89.99    --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rand-0.8.5/src/lib.rs:183:8
#13 89.99     |
#13 89.99 183 | pub fn random<T>() -> T
#13 89.99     |        ^^^^^^
#13 89.99 
#13 90.00 warning: unused import: `bitcoin::hex::DisplayHex`
#13 90.00   --> src/bin/electrs.rs:12:5
#13 90.00    |
#13 90.00 12 | use bitcoin::hex::DisplayHex;
#13 90.00    |     ^^^^^^^^^^^^^^^^^^^^^^^^
#13 90.00    |
#13 90.00    = note: `#[warn(unused_imports)]` on by default
#13 90.00 
#13 90.00 For more information about this error, try `rustc --explain E0425`.
#13 90.01 warning: `electrs` (bin "electrs") generated 1 warning
#13 90.01 error: could not compile `electrs` (bin "electrs") due to previous error; 1 warning emitted
#13 90.01 warning: build failed, waiting for other jobs to finish...
#13 114.2 error: failed to compile `electrs v0.4.1 (/app/electrs)`
```

but only during `cargo install` run! command to reproduce: `cargo install --jobs $(nproc) --root /app/electrs_bitcoin --locked --path . --features electrum-discovery` . It'e reproducible also local (not only on CI)

The fix is to introduce rand crate and use its rng for random bytes generations. The project already depends on rand crate indirectly through bitcoin::secp256k1 when bitcoin rand feature is enabled (see `cargo tree -e features`).
