### PR TITLE
Add missing Auto-Compaction for cache_db

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -292,6 +292,7 @@ impl Indexer {
         );
         start_fetcher(self.from, &daemon, to_index)?.map(|blocks| self.index(&blocks));
         self.start_auto_compactions(&self.store.history_db);
+        self.start_auto_compactions(&self.store.cache_db);
 
         if let DBFlush::Disable = self.flush {
             debug!("flushing to disk");


### PR DESCRIPTION
  **Background**

  Electrs has three RocksDB databases:
  - txstore_db - Stores raw transactions, blocks, confirmations
  - history_db - Stores address histories and spending relationships
  - cache_db - Stores aggregated stats and UTXO sets

  During initial sync, auto-compaction is disabled for faster bulk writes. After sync completes, the indexer calls start_auto_compactions() to:
  1. Perform one-time full compaction (blocking)
  2. Mark database as compacted (marker key b"F")
  3. Enable auto-compaction going forward

  **The Bug**

  In src/new_index/schema.rs around line 285-294, the update() method calls:
  self.start_auto_compactions(&self.store.txstore_db);   // ✓ Called
  // ... processing ...
  self.start_auto_compactions(&self.store.history_db);   // ✓ Called
  // MISSING: self.start_auto_compactions(&self.store.cache_db);  // ✗ Never called

  Result: cache_db never gets compacted and accumulates L0 files indefinitely.

  **Root Cause**

  Git history analysis (commit 2699560 from Jan 31, 2019):
  - The cache_db was created and split out from history_db
  - Looks like a forgotten start_auto_compaction call for the new cache_db

  **Impact**

  Example from production system:
```
  Level Files Size(MB)
  ---------------------
    L0  1372   479.17
```
   
  Problems:
  1. Read amplification: Every cache query must check all 1372 L0 files
  2. Performance degradation: Cache lookups take longer
  3. Query latency: Defeats the purpose of having a cache

  **Proposed Fix**

  Add the following to schema.rs after line 294:
  self.start_auto_compactions(&self.store.cache_db);


  **Why This Matters**

  - Background cleanup: Auto-compaction will gradually merge L0 files during normal operation
  - Production impact: Improves cache performance which affects all queries
 

  **NOTE:**
     On upgrade, this would:
     1. Detect no marker key (first time)
     2. Block for 10-60 seconds doing full compaction of cache_db
     3. Write marker key
     4. Enable auto-compaction
     5. Future restarts are instant
    