### PR TITLE
Add GitLab CI workflow to trigger pipelines

### DIFF
--- a/.github/workflows/start-gitlab.yml
+++ b/.github/workflows/start-gitlab.yml
@@ -1,0 +1,55 @@
+name: Start GitLab CI
+on:
+  # Use pull_request_target to run the workflow from the base branch (e.g., main)
+  # This ensures the trusted workflow logic executes, even for PRs from forks.
+  # It also grants access to secrets needed for the trigger.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+jobs:
+  trigger-gitlab:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start Gitlab Pipeline
+        env:
+          # Get trigger config from secrets
+          GL_TRIGGER_TOKEN: ${{ secrets.GL_TRIGGER_TOKEN }}
+          GL_TRIGGER_URL: ${{ secrets.GL_TRIGGER_URL }}
+          # Use a specific ref from secrets if provided, otherwise default to the PR's head branch name
+          GL_TRIGGER_REF: ${{ secrets.GL_TRIGGER_REF || github.event.pull_request.head.ref }}
+          # --- Variables to pass to GitLab ---
+          # The commit SHA in the GitHub PR
+          GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha }}
+          # The ref (branch name) of the PR head
+          GITHUB_PR_REF: ${{ github.event.pull_request.head.ref }}
+          # The repository name (e.g., 'your-org/your-repo')
+          GITHUB_REPO: ${{ github.repository }}
+          # The GitHub token for reporting status back
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+        run: |
+          # --- Safety Checks ---
+          # Ensure critical secrets are actually available (they should be with pull_request_target)
+          if [ -z "$GL_TRIGGER_TOKEN" ]; then
+            echo "::error::GL_TRIGGER_TOKEN secret is missing or unavailable!"
+            exit 1
+          fi
+          if [ -z "$GITHUB_TOKEN" ]; then
+            echo "::error::GITHUB_TOKEN is empty. Secrets may not be properly accessed."
+            exit 1
+          fi
+          # Ensure URL is set
+          if [ -z "$GL_TRIGGER_URL" ]; then
+            echo "::error::GL_TRIGGER_URL secret is missing or unavailable!"
+            exit 1
+          fi
+
+          echo "Triggering GitLab pipeline for SHA: ${GITHUB_PR_SHA}"
+          curl --fail --silent --show-error --request POST \
+            --form token="${GL_TRIGGER_TOKEN}" \
+            --form ref="${GL_TRIGGER_REF}" \
+            --form "variables[GITHUB_PR_SHA]=${GITHUB_PR_SHA}" \
+            --form "variables[GITHUB_PR_REF]=${GITHUB_PR_REF}" \
+            --form "variables[GITHUB_REPO]=${GITHUB_REPO}" \
+            --form "variables[GITHUB_REPO_URL]=${GITHUB_REPO_URL}" \
+            "${GL_TRIGGER_URL}" > /dev/null
+          echo "GitLab pipeline triggered."


### PR DESCRIPTION
Creating new workflow to run additional tests/validation in GitLab.

Matches pattern that is used in esplora project:
     https://github.com/Blockstream/esplora/blob/master/.github/workflows/start-gitlab.yml