### PR TITLE
Bitcoind 29.0 added additional error messages for getblock, updating

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -620,7 +620,9 @@ impl Daemon {
                 Ok(blocks) => break blocks,
                 Err(e) => {
                     let err_msg = format!("{e:?}");
-                    if err_msg.contains("Block not found on disk") {
+                    if err_msg.contains("Block not found on disk")
+                       || err_msg.contains("Block not available") 
+                    {
                         // There is a small chance the node returns the header but didn't finish to index the block
                         log::warn!("getblocks failing with: {e:?} trying {attempts} more time")
                     } else {


### PR DESCRIPTION
We saw this panic in our electrs:

```
thread 'bitcoind_fetcher' panicked at src/daemon.rs:623:25:
failed to get blocks from bitcoind: Error(RpcError(-1, "Block not available (not fully downloaded)", "getblock"), State { next_error: None, backtrace: InternalBacktrace { backtrace: None } })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

That line of code in daemon.rs was checking an error message string to retry or panic:
  `  if err_msg.contains("Block not found on disk") `

Found that:
That new error messages that start with "Block not available" were introduced in commit 5290cbd58504dcbab97cb0944b3ae0a0f79c4502 by Martin Zumsande on July 8, 2024. 

Here are the details:
Commit: 5290cbd5 — "rpc: Improve getblock / getblockstats error when only header is available."
PR: [bitcoin/bitcoin#30410](https://github.com/bitcoin/bitcoin/pull/30410) 
— "rpc, rest: Improve block rpc error handling, check header before attempting to read block data."

Purpose: The commit improves the error message returned by the getblock and getblockstats RPCs. Before this change, if a node only had the block header (but not the full block data), the code would still attempt ReadRawBlockFromDisk(), which would fail with a less informative error. This change checks the header's nStatus field first and returns the clearer "Block not available (not fully downloaded)" message instead.

First release: This was first included in Bitcoin Core v29.0.
The error lives in src/rpc/blockchain.cpp at line 682 (on the current master branch).


**_Adding code to look for both strings to support all 3 getblock errors._**