### PR TITLE
Use case-insenitive match for HTTP header (Content-Length extraction)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -263,7 +263,7 @@ impl Connection {
             } else if in_header {
                 let parts: Vec<&str> = line.splitn(2, ": ").collect();
                 if parts.len() == 2 {
-                    headers.insert(parts[0].to_owned(), parts[1].to_owned());
+                    headers.insert(parts[0].to_lowercase(), parts[1].to_owned());
                 } else {
                     warn!("invalid header: {:?}", line);
                 }
@@ -276,7 +276,7 @@ impl Connection {
         let contents =
             contents.chain_err(|| ErrorKind::Connection("no reply from daemon".to_owned()))?;
         let contents_length: &str = headers
-            .get("Content-Length")
+            .get("content-length")
             .chain_err(|| format!("Content-Length is missing: {:?}", headers))?;
         let contents_length: usize = contents_length
             .parse()


### PR DESCRIPTION
Fixes #193 
Electr relies on the value from the "Content-Length" HTTP header to check the length of the received RPC response. Parsing of the HTTP header is done directly, and it's done case-sensitive. This is fine with bitcoin code nodes, that use the "Content-Length" title case format, but it's not standards compliant, and fails with other providers, e.g. a third-party proxy between the bitcoin node and electrs.
The fix is rather straigtforward: store headers lowercase, and compare against the lower case version.,