### PR TITLE
feat: shared LRU block cache across all three DBs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -242,9 +242,9 @@ impl Config {
             ).arg(
                 Arg::with_name("db_block_cache_mb")
                     .long("db-block-cache-mb")
-                    .help("RocksDB block cache size in MB per database. Bounds index/filter block memory; use 4096+ for initial sync to avoid table-reader heap growth.")
+                    .help("RocksDB block cache size in MB (shared across all databases). Bounds index/filter block memory; use 4096+ for initial sync to avoid table-reader heap growth.")
                     .takes_value(true)
-                    .default_value("8")
+                    .default_value("24")
             ).arg(
                 Arg::with_name("db_parallelism")
                     .long("db-parallelism")

--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -152,7 +152,7 @@ impl DB {
 
         // Configure block cache and table options
         let mut block_opts = rocksdb::BlockBasedOptions::default();
-        let owned_cache;
+        let owned_cache: rocksdb::Cache;
         let cache = match shared_cache {
             Some(c) => c,
             None => {

--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -91,6 +91,10 @@ pub enum DBFlush {
 
 impl DB {
     pub fn open(path: &Path, config: &Config, verify_compat: bool) -> DB {
+        Self::open_with_cache(path, config, verify_compat, None)
+    }
+
+    pub fn open_with_cache(path: &Path, config: &Config, verify_compat: bool, shared_cache: Option<&rocksdb::Cache>) -> DB {
         debug!("opening DB at {:?}", path);
         let mut db_opts = rocksdb::Options::default();
         db_opts.create_if_missing(true);
@@ -148,8 +152,16 @@ impl DB {
 
         // Configure block cache and table options
         let mut block_opts = rocksdb::BlockBasedOptions::default();
-        let cache_size_bytes = config.db_block_cache_mb * 1024 * 1024;
-        block_opts.set_block_cache(&rocksdb::Cache::new_lru_cache(cache_size_bytes));
+        let owned_cache;
+        let cache = match shared_cache {
+            Some(c) => c,
+            None => {
+                let cache_size_bytes = config.db_block_cache_mb * 1024 * 1024;
+                owned_cache = rocksdb::Cache::new_lru_cache(cache_size_bytes);
+                &owned_cache
+            }
+        };
+        block_opts.set_block_cache(cache);
         // When --cache-index-filter-blocks is passed, store index and filter blocks
         // inside the block cache so their memory is bounded by --db-block-cache-mb.
         // Without this (the default), RocksDB keeps them on the heap where they may

--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -90,11 +90,7 @@ pub enum DBFlush {
 }
 
 impl DB {
-    pub fn open(path: &Path, config: &Config, verify_compat: bool) -> DB {
-        Self::open_with_cache(path, config, verify_compat, None)
-    }
-
-    pub fn open_with_cache(path: &Path, config: &Config, verify_compat: bool, shared_cache: Option<&rocksdb::Cache>) -> DB {
+    pub fn open(path: &Path, config: &Config, verify_compat: bool, shared_cache: &rocksdb::Cache) -> DB {
         debug!("opening DB at {:?}", path);
         let mut db_opts = rocksdb::Options::default();
         db_opts.create_if_missing(true);
@@ -152,16 +148,7 @@ impl DB {
 
         // Configure block cache and table options
         let mut block_opts = rocksdb::BlockBasedOptions::default();
-        let owned_cache: rocksdb::Cache;
-        let cache = match shared_cache {
-            Some(c) => c,
-            None => {
-                let cache_size_bytes = config.db_block_cache_mb * 1024 * 1024;
-                owned_cache = rocksdb::Cache::new_lru_cache(cache_size_bytes);
-                &owned_cache
-            }
-        };
-        block_opts.set_block_cache(cache);
+        block_opts.set_block_cache(shared_cache);
         // When --cache-index-filter-blocks is passed, store index and filter blocks
         // inside the block cache so their memory is bounded by --db-block-cache-mb.
         // Without this (the default), RocksDB keeps them on the heap where they may

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -68,17 +68,17 @@ impl Store {
         // needs without being artificially capped at 1/3 of the total.
         let cache_size_bytes = config.db_block_cache_mb * 1024 * 1024;
         let shared_cache = rocksdb::Cache::new_lru_cache(cache_size_bytes);
-        info!("shared LRU block cache: db_block_cache_mb='{}'", config.db_block_cache_mb);
+        debug!("shared LRU block cache: db_block_cache_mb='{}'", config.db_block_cache_mb);
 
-        let txstore_db = DB::open_with_cache(&path.join("txstore"), config, verify_compat, Some(&shared_cache));
+        let txstore_db = DB::open(&path.join("txstore"), config, verify_compat, &shared_cache);
         let added_blockhashes = load_blockhashes(&txstore_db, &BlockRow::done_filter());
         debug!("{} blocks were added", added_blockhashes.len());
 
-        let history_db = DB::open_with_cache(&path.join("history"), config, verify_compat, Some(&shared_cache));
+        let history_db = DB::open(&path.join("history"), config, verify_compat, &shared_cache);
         let indexed_blockhashes = load_blockhashes(&history_db, &BlockRow::done_filter());
         debug!("{} blocks were indexed", indexed_blockhashes.len());
 
-        let cache_db = DB::open_with_cache(&path.join("cache"), config, verify_compat, Some(&shared_cache));
+        let cache_db = DB::open(&path.join("cache"), config, verify_compat, &shared_cache);
 
         let db_metrics = Arc::new(RocksDbMetrics::new(&metrics));
         txstore_db.start_stats_exporter(Arc::clone(&db_metrics), "txstore_db");

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -61,15 +61,24 @@ impl Store {
     pub fn open(config: &Config, metrics: &Metrics, verify_compat: bool) -> Self {
         let path = config.db_path.join("newindex");
 
-        let txstore_db = DB::open(&path.join("txstore"), config, verify_compat);
+        // Create a single shared LRU cache for all three DBs. The total size is
+        // --db-block-cache-mb (not multiplied by 3). RocksDB's LRU cache is
+        // thread-safe, so all DBs share one eviction pool. This lets the
+        // txstore (which holds the bulk of the data) claim as much cache as it
+        // needs without being artificially capped at 1/3 of the total.
+        let cache_size_bytes = config.db_block_cache_mb * 1024 * 1024;
+        let shared_cache = rocksdb::Cache::new_lru_cache(cache_size_bytes);
+        info!("shared LRU block cache: db_block_cache_mb='{}'", config.db_block_cache_mb);
+
+        let txstore_db = DB::open_with_cache(&path.join("txstore"), config, verify_compat, Some(&shared_cache));
         let added_blockhashes = load_blockhashes(&txstore_db, &BlockRow::done_filter());
         debug!("{} blocks were added", added_blockhashes.len());
 
-        let history_db = DB::open(&path.join("history"), config, verify_compat);
+        let history_db = DB::open_with_cache(&path.join("history"), config, verify_compat, Some(&shared_cache));
         let indexed_blockhashes = load_blockhashes(&history_db, &BlockRow::done_filter());
         debug!("{} blocks were indexed", indexed_blockhashes.len());
 
-        let cache_db = DB::open(&path.join("cache"), config, verify_compat);
+        let cache_db = DB::open_with_cache(&path.join("cache"), config, verify_compat, Some(&shared_cache));
 
         let db_metrics = Arc::new(RocksDbMetrics::new(&metrics));
         txstore_db.start_stats_exporter(Arc::clone(&db_metrics), "txstore_db");


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
  - Creates a single shared `rocksdb::Cache` passed to all three DBs (txstore, history, cache) instead of each DB creating its own                                                                                                                  
  - `--db-block-cache-mb` now controls the total cache size, not per-DB
  - Allows for configuration to eliminate wasted allocation on the tiny cache_db (~3 MB of data was getting a full equal share of cache)                                                                                                                                       
  - txstore and history claim cache proportional to actual usage via LRU eviction                                                                                                                                                                   
  - updated default db-block-cache-mb from 8 --> 24 so uses same amount as before change
                                                                                                                                                                                                                                                    
  ## Background                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                    
  electrs maintains three RocksDB instances: txstore (~900 GB), history (~555 GB), and cache (~3 MB). Previously each got its own block cache of `--db-block-cache-mb` size, so the total was 3x the configured value. The cache_db's allocation sat
   almost entirely unused.
                                                                                                                                                                                                                                                    
  With a shared cache, the same total memory is used more efficiently. txstore (which holds the bulk of the data and handles the most lookups) naturally claims the lion's share through LRU eviction, while cache_db uses only what it needs.      
   
  **Migration note:** `--db-block-cache-mb` now means total, not per-DB. To match previous behavior, triple the old value (e.g. old `--db-block-cache-mb=6144` = 18 GB total → new `--db-block-cache-mb=18432`).                                                                                                                                          
                  
Note: future step is to convert the LRU --> HyperClockCache

  ## Test plan                                                                                                                                                                                                                                      
                  
  - [x] `cargo check` / `cargo build` with default features                                                                                                                                                                                         
  - [x] `cargo build --features liquid`
  - [x] Verify Prometheus `block-cache-capacity` metric is identical across all three DBs                                                                                                                                                           
  - [x] Verify `block-cache-usage` reflects shared pool (not 3 independent pools)                                                                                                                                                                   
  - [x] No functional changes — same data, same queries, just shared cache           