### PR TITLE
Fix incorrect block progress calculation in header download log

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -784,8 +784,8 @@ impl Daemon {
             info!(
                 "downloaded {}/{} block headers ({:.0}%)",
                 result.len(),
-                tip_height,
-                result.len() as f32 / tip_height as f32 * 100.0
+                tip_height + 1,
+                result.len() as f32 / (tip_height + 1) as f32 * 100.0
             );
         }
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
  The `downloaded X/Y block headers (Z%)` log in `get_all_headers` uses `tip_height` as the denominator, but `tip_height` is 0-indexed while `result.len()` counts total headers. This causes:                                          
                                                                                                                                                                                                                                        
  - **Progress >100%**: A chain with genesis (height 0) + one mined block (height 1) has 2 headers but `tip_height=1`, logging `2/1 (200%)`                                                                                             
  - **Division by zero**: When only the genesis block exists, `tip_height=0`                                                                                                                                                            
                                                                                                                                                                                                                                        
  The fix uses `tip_height + 1` as the denominator, which matches the actual header count (`0..=tip_height`).                                                                                                                           
                                                                                                                                                                                                                                        
  Fixes #197                         