### PR TITLE
feat(logging): default to info-level logging  

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Install Rust, Bitcoin Core (no `txindex` needed) and the `clang` and `cmake` pac
 ```bash
 $ git clone https://github.com/blockstream/electrs && cd electrs
 $ git checkout new-index
-$ cargo run --release --bin electrs -- -vvvv --daemon-dir ~/.bitcoin
+$ cargo run --release --bin electrs -- --daemon-dir ~/.bitcoin
 
 # Or for liquid:
-$ cargo run --features liquid --release --bin electrs -- -vvvv --network liquid --daemon-dir ~/.liquid
+$ cargo run --features liquid --release --bin electrs -- --network liquid --daemon-dir ~/.liquid
 ```
 
 See [electrs's original documentation](https://github.com/romanz/electrs/blob/master/doc/usage.md) for more detailed instructions.

--- a/contrib/electrs.service
+++ b/contrib/electrs.service
@@ -3,7 +3,7 @@ Description=Electrum Rust Server
 
 [Service]
 Type=simple
-ExecStart=/path/to/electrs/target/release/electrs -vvvv --db-dir /path/to/electrs/db/
+ExecStart=/path/to/electrs/target/release/electrs --db-dir /path/to/electrs/db/
 Restart=on-failure
 RestartSec=60
 Environment="RUST_BACKTRACE=1"

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -32,7 +32,7 @@ Otherwise, [`~/.bitcoin/.cookie`](https://github.com/bitcoin/bitcoin/blob/021218
 
 First index sync should take ~1.5 hours:
 ```bash
-$ cargo run --release -- -vvv --timestamp --db-dir ./db [--cookie="USER:PASSWORD"]
+$ cargo run --release -- --timestamp --db-dir ./db [--cookie="USER:PASSWORD"]
 2018-08-17T18:27:42 - INFO - NetworkInfo { version: 179900, subversion: "/Satoshi:0.17.99/" }
 2018-08-17T18:27:42 - INFO - BlockchainInfo { chain: "main", blocks: 537204, headers: 537204, bestblockhash: "0000000000000000002956768ca9421a8ddf4e53b1d81e429bd0125a383e3636", pruned: false, initialblockdownload: false }
 2018-08-17T18:27:42 - DEBUG - opening DB at "./db/mainnet"

--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -57,10 +57,13 @@ fn run_server(config: Arc<Config>, salt_rwlock: Arc<RwLock<String>>) -> Result<(
     let metrics = Metrics::new(config.monitoring_addr);
     metrics.start();
 
+    info!("starting electrs");
+
     if let Some(zmq_addr) = config.zmq_addr.as_ref() {
         zmq::start(&format!("tcp://{zmq_addr}"), block_hash_notify);
     }
 
+    info!("connecting to daemon at {}", config.daemon_rpc_addr);
     let daemon = Arc::new(Daemon::new(
         &config.daemon_dir,
         &config.blocks_dir,
@@ -71,6 +74,7 @@ fn run_server(config: Arc<Config>, salt_rwlock: Arc<RwLock<String>>) -> Result<(
         signal.clone(),
         &metrics,
     )?);
+    info!("opening database at {}", config.db_path.display());
     let store = Arc::new(Store::open(&config, &metrics, true));
     let mut indexer = Indexer::open(
         Arc::clone(&store),
@@ -78,7 +82,9 @@ fn run_server(config: Arc<Config>, salt_rwlock: Arc<RwLock<String>>) -> Result<(
         &config,
         &metrics,
     );
+    info!("starting initial sync");
     let mut tip = indexer.update(&daemon)?;
+    info!("initial sync complete, tip at {}", tip);
 
     let chain = Arc::new(ChainQuery::new(
         Arc::clone(&store),
@@ -93,6 +99,7 @@ fn run_server(config: Arc<Config>, salt_rwlock: Arc<RwLock<String>>) -> Result<(
         precache::precache(&chain, precache_scripthashes);
     }
 
+    info!("loading mempool");
     let mempool = Arc::new(RwLock::new(Mempool::new(
         Arc::clone(&chain),
         &metrics,
@@ -129,6 +136,8 @@ fn run_server(config: Arc<Config>, salt_rwlock: Arc<RwLock<String>>) -> Result<(
         &metrics,
         Arc::clone(&salt_rwlock),
     );
+
+    info!("startup complete");
 
     let main_loop_count = metrics.gauge(MetricOpts::new(
         "electrs_main_loop_count",

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,7 +109,7 @@ impl Config {
                 Arg::with_name("verbosity")
                     .short("v")
                     .multiple(true)
-                    .help("Increase logging verbosity"),
+                    .help("Increase logging verbosity (default: info, -v: debug, -vv: trace)"),
             )
             .arg(
                 Arg::with_name("timestamp")
@@ -464,7 +464,9 @@ impl Config {
             .map(|s| serde_json::from_str(s).expect("invalid --electrum-public-hosts"));
 
         let mut log = stderrlog::new();
-        log.verbosity(m.occurrences_of("verbosity") as usize);
+        // Base verbosity is 2 (Info), each -v flag adds one level:
+        // no flags = Info, -v = Debug, -vv = Trace
+        log.verbosity(2 + m.occurrences_of("verbosity") as usize);
         log.timestamp(if m.is_present("timestamp") {
             stderrlog::Timestamp::Millisecond
         } else {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -789,7 +789,7 @@ impl Daemon {
 
             result.append(&mut headers);
 
-            info!(
+            debug!(
                 "downloaded {}/{} block headers ({:.0}%)",
                 result.len(),
                 tip_height + 1,

--- a/src/electrum/discovery.rs
+++ b/src/electrum/discovery.rs
@@ -588,7 +588,7 @@ mod tests {
 
         debug!("{:#?}", discovery);
 
-        info!("{}", json!(discovery.get_servers()));
+        debug!("{}", json!(discovery.get_servers()));
 
         Ok(())
     }

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -876,7 +876,7 @@ impl RPC {
                     let salt = salt_rwlock.read().unwrap().clone();
 
                     let spawned = spawn_thread("peer", move || {
-                        info!("[{}] connected peer", addr);
+                        debug!("[{}] connected peer", addr);
                         let conn = Connection::new(
                             query,
                             stream,
@@ -890,7 +890,7 @@ impl RPC {
                             salt,
                         );
                         conn.run(receiver);
-                        info!("[{}] disconnected peer", addr);
+                        debug!("[{}] disconnected peer", addr);
                         let _ = garbage_sender.send(std::thread::current().id());
                     });
 

--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -91,7 +91,7 @@ pub enum DBFlush {
 
 impl DB {
     pub fn open(path: &Path, config: &Config, verify_compat: bool, shared_cache: &rocksdb::Cache) -> DB {
-        debug!("opening DB at {:?}", path);
+        info!("opening DB at {:?}", path);
         let mut db_opts = rocksdb::Options::default();
         db_opts.create_if_missing(true);
         db_opts.set_max_open_files(100_000); // TODO: make sure to `ulimit -n` this process correctly

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -429,21 +429,21 @@ impl Indexer {
 
         if let DBFlush::Disable = self.flush {
             let t = std::time::Instant::now();
-            debug!("flushing txstore_db to disk");
+            info!("flushing txstore_db to disk");
             self.store.txstore_db.flush();
-            debug!("flushing txstore_db complete in {:.1?}", t.elapsed());
+            info!("flushing txstore_db complete in {:.1?}", t.elapsed());
 
             let t = std::time::Instant::now();
-            debug!("flushing history_db to disk");
+            info!("flushing history_db to disk");
             self.store.history_db.flush();
-            debug!("flushing history_db complete in {:.1?}", t.elapsed());
+            info!("flushing history_db complete in {:.1?}", t.elapsed());
 
             // cache_db receives WAL-disabled writes when --address-search is enabled,
             // so it needs the same explicit flush to ensure durability.
             let t = std::time::Instant::now();
-            debug!("flushing cache_db to disk");
+            info!("flushing cache_db to disk");
             self.store.cache_db.flush();
-            debug!("flushing cache_db complete in {:.1?}", t.elapsed());
+            info!("flushing cache_db complete in {:.1?}", t.elapsed());
 
             self.flush = DBFlush::Enable;
         }

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -72,11 +72,11 @@ impl Store {
 
         let txstore_db = DB::open(&path.join("txstore"), config, verify_compat, &shared_cache);
         let added_blockhashes = load_blockhashes(&txstore_db, &BlockRow::done_filter());
-        debug!("{} blocks were added", added_blockhashes.len());
+        info!("{} blocks were added", added_blockhashes.len());
 
         let history_db = DB::open(&path.join("history"), config, verify_compat, &shared_cache);
         let indexed_blockhashes = load_blockhashes(&history_db, &BlockRow::done_filter());
-        debug!("{} blocks were indexed", indexed_blockhashes.len());
+        info!("{} blocks were indexed", indexed_blockhashes.len());
 
         let cache_db = DB::open(&path.join("cache"), config, verify_compat, &shared_cache);
 
@@ -101,7 +101,7 @@ impl Store {
                     .expect("invalid header chain")
                     .prev_blockhash;
             }
-            debug!(
+            info!(
                 "{} headers were loaded, tip at {:?}",
                 headers_map.len(),
                 tip_hash

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -685,7 +685,7 @@ fn handle_request(
         None => HashMap::new(),
     };
 
-    info!("handle {:?} {:?}", method, uri);
+    debug!("handle {:?} {:?}", method, uri);
     match (
         &method,
         path.get(0),


### PR DESCRIPTION
## Summary                

  - Electrs has been seen dying silently in environments running with no                                                                                                                                                                            
    `-v` flag (error-only logging), making it impossible to diagnose where
    they got stuck.                                                                                                                                                                                                                                 
  - Base log level is now `info` by default. `-v` selects `debug`, `-vv`
    selects `trace`.                                                                                                                                                                                                                                
  - Adds `info!` milestone logs at each startup phase: daemon connection,
    DB open, initial sync start/complete, mempool load, startup complete.                                                                                                                                                                           
  - Promotes key `debug!` logs in `schema.rs` and `db.rs` to `info!` so
    block/header counts and DB open are visible at the default level.                                                                                                                                                                               
  - Demotes noisy per-request and per-peer logs to `debug!` so the default                                                                                                                                                                          
    output stays readable once startup completes.                                                                                                                                                                                                   
  - Updates README, `doc/usage.md`, and `contrib/electrs.service` to drop                                                                                                                                                                           
    the now-unnecessary `-vvvv` flag.                                                                                                                                                                                                               
                            
  ## Test plan                                                                                                                                                                                                                                      
                            
  - [x] Run electrs with no `-v` flag — startup milestones are logged and                                                                                                                                                                           
        output stays quiet during steady-state operation.
  - [x] Run electrs with `-v` / `-vv` — per-request and peer logs return                                                                                                                                                                            
        as expected.                                                                                                                                                                                                                                
  - [x] Kill electrs mid-startup — last log line indicates which phase it                                                                                                                                                                           
        was in.                                                                                                                                                                                                                                     
                                                            