### PR TITLE
fix(electrum): handle shutdown race in acceptor thread

### DIFF
--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -766,7 +766,11 @@ impl RPC {
                             }
                         })
                     }
-                    Notification::Exit => acceptor.send(None).unwrap(), // mark acceptor as done
+                    Notification::Exit => {
+                        if acceptor.send(None).is_err() {
+                            warn!("acceptor already shut down before Exit notification");
+                        }
+                    }
                 }
             }
         });
@@ -789,7 +793,9 @@ impl RPC {
                 stream
                     .set_nonblocking(false)
                     .expect("failed to set connection as blocking");
-                acceptor.send(Some((stream, addr))).expect("send failed");
+                if acceptor.send(Some((stream, addr))).is_err() {
+                    break; // receiver dropped, server is shutting down
+                }
             }
         });
         chan


### PR DESCRIPTION
 ## Summary      
                                                                                                                                                                                                                                                    
  Fixes a shutdown race we saw in the Electrum RPC server that caused the
  `acceptor` thread to panic with `"send failed"` when a TCP connection                                                                                                                                                                             
  arrived at the exact moment the server was tearing down.             
                                                                                                                                                                                                                                                    
  ## Root Cause                                                                                                                                                                                                                                     
               
  The `acceptor` thread and the `rpc` thread communicate via a channel:                                                                                                                                                                             
                                                                                                                                                                                                                                                    
  - The `acceptor` thread calls `listener.accept()` in a loop and sends
    each new connection as `Some((stream, addr))` to the `rpc` thread                                                                                                                                                                               
  - On shutdown, the `notification` thread sends `None` into the channel
  - The `rpc` thread receives `None`, exits its `while let Some(...)` loop,                                                                                                                                                                         
    and **drops the channel receiver**                                                                                                                                                                                                              
  - If the `acceptor` thread accepts a new TCP connection at this moment                                                                                                                                                                            
    and calls `send(Some(...))`, the send fails because the receiver is                                                                                                                                                                             
    already gone → `.expect("send failed")` → **panic**                                                                                                                                                                                             
                                                                                                                                                                                                                                                    
  This is a normal production scenario: on a live Electrum server with                                                                                                                                                                              
  active wallet connections, a client connecting during shutdown is                                                                                                                                                                                 
  expected.                                                        
                                                                                                                                                                                                                                                    