### PR TITLE
fix(db): avoid long flush stall on restart

### DIFF
--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -99,28 +99,9 @@ impl DB {
         db_opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
         db_opts.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
         db_opts.set_target_file_size_base(1_073_741_824);
-        // Bulk-load compaction: allow L0 files to accumulate to a bounded limit
-        // before compacting. This reduces write amplification compared to the
-        // default trigger of 4, while keeping the file count — and therefore
-        // bloom-filter memory and lookup cost — bounded.
-        //
-        // With bloom filters at 10 bits/key and a 512 MB write buffer, each L0
-        // file has ~7.8 M keys, so its filter block is ~9.75 MB. At 64 files
-        // that is ~625 MB of pinned filter blocks — well within an 8 GB cache.
-        // Each lookup checks 64 bloom filters (fast, in-memory) and reads from
-        // only ~0.64 files on average (1 % false-positive rate × 64 files).
-        //
-        // Set slowdown/stop triggers well above the compaction trigger so writes
-        // are never stalled while background compaction catches up.
-        // Disable the pending-compaction-bytes stall so the large backlog that
-        // builds up during the bulk load does not block writes.
-        const L0_BULK_TRIGGER: i32 = 64;
-        db_opts.set_level_zero_file_num_compaction_trigger(L0_BULK_TRIGGER);
-        db_opts.set_level_zero_slowdown_writes_trigger(L0_BULK_TRIGGER * 4);
-        db_opts.set_level_zero_stop_writes_trigger(L0_BULK_TRIGGER * 8);
-        db_opts.set_hard_pending_compaction_bytes_limit(0);
-        db_opts.set_soft_pending_compaction_bytes_limit(0);
-
+        // L0 compaction triggers are left at RocksDB defaults (4/20/36) here.
+        // After open, apply_bulk_load_triggers() widens them for initial sync
+        // when the full-compaction sentinel 'F' is absent.
 
         let parallelism: i32 = config.db_parallelism.try_into()
             .expect("db_parallelism value too large for i32");
@@ -188,6 +169,13 @@ impl DB {
         let db = DB {
             db: Arc::new(rocksdb::DB::open(&db_opts, path).expect("failed to open RocksDB"))
         };
+        let key = b"F".to_vec();
+        if db.get(&key).is_none() {
+            info!("sentinel 'F' absent in {:?} — widening L0 triggers for bulk load", path);
+            db.apply_bulk_load_triggers();
+        } else {
+            info!("sentinel 'F' present in {:?} — using steady-state L0 triggers", path);
+        }
         if verify_compat {
             db.verify_compatibility(config);
         }
@@ -204,23 +192,51 @@ impl DB {
         info!("finished full compaction on {:?} in elapsed='{:.1?}'", self.db, elapsed);
     }
 
-    pub fn enable_auto_compaction(&self) {
-       // Reset L0 triggers and pending-compaction stall thresholds to RocksDB
-       // defaults, so that steady-state operation compacts promptly and avoids
-       // unbounded compaction backlogs that cause read latency spikes.
-       // RocksDB defaults (stable since v5.x through v10.4.2). Hardcoded because
-       // set_options() doesn't return previous values and the Rust bindings lack getters.
+    fn apply_bulk_load_triggers(&self) {
+        const L0_BULK_TRIGGER: u32 = 64;
+        let trigger = L0_BULK_TRIGGER.to_string();
+        let slowdown = (L0_BULK_TRIGGER * 4).to_string();
+        let stop = (L0_BULK_TRIGGER * 8).to_string();
 
+        let opts = [
+            ("level0_file_num_compaction_trigger", trigger.as_str()),
+            ("level0_slowdown_writes_trigger", slowdown.as_str()),
+            ("level0_stop_writes_trigger", stop.as_str()),
+            ("soft_pending_compaction_bytes_limit", "0"),
+            ("hard_pending_compaction_bytes_limit", "0"),
+        ];
+        self.db.set_options(&opts).unwrap();
+    }
+
+    pub fn enable_auto_compaction(&self) {
+        let opts = [("disable_auto_compactions", "false")];
+        self.db.set_options(&opts).unwrap();
+    }
+
+    /// Restore RocksDB-default compaction triggers after bulk-load widening,
+    /// for lower read amplification in steady-state operation.
+    ///
+    /// Must be called only after a compaction has drained L0 and any level-size
+    /// imbalance — otherwise the tightened `level0_stop_writes_trigger` parks
+    /// foreground flushes and sync writes in `WaitUntilFlushWouldNotStallWrites`
+    /// until background compaction catches up. On a mature DB with an hour-long
+    /// bottommost compaction in flight, that wait can exceed 70 minutes.
+    pub fn apply_steady_state_triggers(&self) {
+        // RocksDB internal defaults (cf_options.h, stable since v5.x through v10.4.2).
+        // Hardcoded because set_options() doesn't return previous values and the Rust
+        // bindings lack getters. Update these if RocksDB changes its defaults.
+        let trigger = 4u32.to_string();
+        let slowdown = 20u32.to_string();
+        let stop = 36u32.to_string();
         let soft_limit = (64u64 << 30).to_string(); // 64 GiB
         let hard_limit = (256u64 << 30).to_string(); // 256 GiB
 
         let opts = [
-            ("disable_auto_compactions", "false"),
-            ("level0_file_num_compaction_trigger", "4"),
-            ("level0_slowdown_writes_trigger", "20"),
-            ("level0_stop_writes_trigger", "36"),
-            ("soft_pending_compaction_bytes_limit", &soft_limit),
-            ("hard_pending_compaction_bytes_limit", &hard_limit),
+            ("level0_file_num_compaction_trigger", trigger.as_str()),
+            ("level0_slowdown_writes_trigger", slowdown.as_str()),
+            ("level0_stop_writes_trigger", stop.as_str()),
+            ("soft_pending_compaction_bytes_limit", soft_limit.as_str()),
+            ("hard_pending_compaction_bytes_limit", hard_limit.as_str()),
         ];
         self.db.set_options(&opts).unwrap();
     }

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -283,9 +283,15 @@ impl Indexer {
     fn start_auto_compactions(&self, db: &DB) {
         let key = b"F".to_vec();
         if db.get(&key).is_none() {
+            info!("full-compaction sentinel 'F' not found — running one-time full compaction");
             db.full_compaction();
+            info!("full compaction finished — tightening triggers to steady-state values");
+            db.apply_steady_state_triggers();
             db.put_sync(&key, b"");
             assert!(db.get(&key).is_some());
+            info!("full-compaction sentinel 'F' set");
+        } else {
+            info!("full-compaction sentinel 'F' found — skipping full compaction");
         }
         db.enable_auto_compaction();
     }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
  Fix a flush stall that occurs on restart of a mature electrs DB built from `91b883a` or later.                                                                                                                                                    
                                                                                                                                                                                                                                                    
  On restart, `DB::open` applied bulk-load L0 triggers (64/256/512) unconditionally. Later in                                                                                                                                                       
  `update()`, `enable_auto_compaction()` reset them to RocksDB defaults (4/20/36). If L0 held
  more than 36 files at that point — normal after a bulk-load that was interrupted or followed                                                                                                                                                      
  by a restart — the tightened `level0_stop_writes_trigger` immediately put the DB into                                                                                                                                                             
  pre-flush stall territory. The subsequent `db.flush()` parked inside                                                                                                                                                                              
  `WaitUntilFlushWouldNotStallWrites` until background compaction drained L0 below 36.                                                                                                                                                              
                                                                                                
  The stall duration was amplified by compaction thread contention. RocksDB schedules                                                                                                                                                               
  compaction by priority score (`L0_files / level0_file_num_compaction_trigger`). With the
  old code opening at trigger=64, the L0 score was low (e.g. 173/64 ≈ 2.7), so L0→L1                                                                                                                                                                
  compaction was deprioritized relative to deep-level jobs (L5+L6→L6) competing for the                                                                                                                                                             
  same background threads. With trigger=4, the score jumps to 173/4 ≈ 43.3, making L0                                                                                                                                                               
  compaction the highest-priority job from the moment of open. When L0 is in the 36–64                                                                                                                                                              
  range, score drops below 1.0 and RocksDB suppresses L0 compaction entirely.      
                                                                                                                                                    
  On testnet with 173 L0 files this caused over 1 hour of indexer freeze on restart.
                                                                                                                                                                                                                                                    
  ## Fix                    

  - **`DB::open()` checks the `F` sentinel before choosing triggers.** When `F` is absent                                                                                                                                                           
    (initial sync incomplete), it widens L0 triggers for bulk load (64/256/512). When `F` is
    present (normal restart), it leaves RocksDB defaults (4/20/36) in place — no runtime                                                                                                                                                            
    `set_options()` needed.                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                    
  - **`apply_bulk_load_triggers()`** — new method that widens L0 triggers and disables                                                                                                                                                              
    pending-compaction-bytes stalls for initial sync throughput.                                                                                                                                                                                    
                            
  - **`apply_steady_state_triggers()`** — restores RocksDB defaults after `full_compaction()`
    drains L0. Called once inside the `F` sentinel gate in `start_auto_compactions()`.                                                                                                                                                              
  
  - **`start_auto_compactions()`** replaces the old `enable_auto_compaction()` trigger-reset                                                                                                                                                        
    logic. On first completion of initial sync (`F` absent), it runs a one-time full compaction,
    restores steady-state triggers, and writes the `F` sentinel. On subsequent calls (`F`                                                                                                                                                           
    present), it only enables auto-compaction.                                                                                                                                                                                                      
                                                                                                                                                                                                                                                    
  - **Operator logging** at info level for which trigger profile is active and whether full                                                                                                                                                         
    compaction runs or is skipped.
                                                                                                                                                                                                                                                    
  ## Test plan
                                                                                                                                                                                                                                                    
  - [x] `cargo check` clean 
  - [x] `cargo test --lib` — 8/8 pass, including `new_index::db::tests::*`
  - [x] `cargo test --test electrum` — 4/4 pass
  - [x] `cargo test --test rest` — 22/22 pass                                                                                                                                                                                                       
  - [x] Deploy to testnet and verify restart completes flush in under a second
  - [x] Confirm `Manual flush start` → `Manual flush finished` in RocksDB LOG are within ms                                                                                                                                                         
  - [x] Verify synced tip resumes advancing from ZMQ notifications immediately after restart    
  - [x] Signet validation run: public signet height `310350 → 310351`, ZMQ block notification to synced-tip update in ~32ms, restart flushes all <1ms from electrs logs / same-ms in RocksDB LOG.
                      