### PR TITLE
startup: decouple precache and mempool sync from server startup

### DIFF
--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -51,6 +51,23 @@ fn fetch_from(config: &Config, store: &Store) -> FetchFrom {
     }
 }
 
+// TODO: configuration for which servers to start
+fn start_servers(
+    config: &Arc<Config>,
+    query: &Arc<Query>,
+    metrics: &Metrics,
+    salt_rwlock: &Arc<RwLock<String>>,
+) -> (rest::Handle, ElectrumRPC) {
+    let rest_server = rest::start(Arc::clone(config), Arc::clone(query));
+    let electrum_server = ElectrumRPC::start(
+        Arc::clone(config),
+        Arc::clone(query),
+        metrics,
+        Arc::clone(salt_rwlock),
+    );
+    (rest_server, electrum_server)
+}
+
 fn run_server(config: Arc<Config>, salt_rwlock: Arc<RwLock<String>>) -> Result<()> {
     let (block_hash_notify, block_hash_receive) = channel::bounded(1);
     let signal = Waiter::start(block_hash_receive);
@@ -94,10 +111,15 @@ fn run_server(config: Arc<Config>, salt_rwlock: Arc<RwLock<String>>) -> Result<(
         &metrics,
     ));
 
+    // Pre-caching is pure cache warming; run it in the background so it doesn't
+    // delay startup. The file is still read upfront to fail fast on a bad path.
     if let Some(ref precache_file) = config.precache_scripts {
         let precache_scripthashes = precache::scripthashes_from_file(precache_file.to_string())
             .expect("cannot load scripts to precache");
-        precache::precache(&chain, precache_scripthashes);
+        let precache_chain = Arc::clone(&chain);
+        thread::spawn(move || {
+            precache::precache(&precache_chain, precache_scripthashes);
+        });
     }
 
     info!("loading mempool");
@@ -106,12 +128,6 @@ fn run_server(config: Arc<Config>, salt_rwlock: Arc<RwLock<String>>) -> Result<(
         &metrics,
         Arc::clone(&config),
     )));
-
-    while !Mempool::update(&mempool, &daemon, &tip)? {
-        // Mempool syncing was aborted because the chain tip moved;
-        // Index the new block(s) and try again.
-        tip = indexer.update(&daemon)?;
-    }
 
     #[cfg(feature = "liquid")]
     let asset_db = config.asset_db_path.as_ref().map(|db_dir| {
@@ -129,15 +145,25 @@ fn run_server(config: Arc<Config>, salt_rwlock: Arc<RwLock<String>>) -> Result<(
         asset_db,
     ));
 
-    // TODO: configuration for which servers to start
-    let rest_server = rest::start(Arc::clone(&config), Arc::clone(&query));
-    let electrum_server = ElectrumRPC::start(
-        Arc::clone(&config),
-        Arc::clone(&query),
-        &metrics,
-        Arc::clone(&salt_rwlock),
-    );
+    // With --serve-during-mempool-sync, the servers start serving chain-based queries
+    // right away while the mempool syncs; /health/ready reports mempool_synced=false
+    // until the initial sync completes, keeping the instance out of LB rotation.
+    let mut servers = if config.serve_during_mempool_sync {
+        Some(start_servers(&config, &query, &metrics, &salt_rwlock))
+    } else {
+        None
+    };
 
+    while !Mempool::update(&mempool, &daemon, &tip)? {
+        // Mempool syncing was aborted because the chain tip moved;
+        // Index the new block(s) and try again.
+        tip = indexer.update(&daemon)?;
+    }
+
+    let (rest_server, electrum_server) = match servers.take() {
+        Some(servers) => servers,
+        None => start_servers(&config, &query, &metrics, &salt_rwlock),
+    };
     info!("startup complete");
 
     let main_loop_count = metrics.gauge(MetricOpts::new(

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,11 @@ pub struct Config {
     pub index_unspendables: bool,
     pub cors: Option<String>,
     pub precache_scripts: Option<String>,
+    /// Start the REST and Electrum servers before the initial mempool sync completes.
+    /// Chain-based queries are fully correct during the sync; mempool-derived data is
+    /// incomplete until /health/ready reports mempool_synced=true, so readiness probes
+    /// must use that endpoint instead of a TCP check when this is enabled.
+    pub serve_during_mempool_sync: bool,
     pub utxos_limit: usize,
     pub electrum_txs_limit: usize,
     pub electrum_banner: String,
@@ -214,6 +219,11 @@ impl Config {
                     .long("precache-scripts")
                     .help("Path to file with list of scripts to pre-cache")
                     .takes_value(true)
+            )
+            .arg(
+                Arg::with_name("serve_during_mempool_sync")
+                    .long("serve-during-mempool-sync")
+                    .help("Start the REST/Electrum servers before the initial mempool sync completes. Requires readiness checks to use /health/ready instead of a TCP probe.")
             )
             .arg(
                 Arg::with_name("utxos_limit")
@@ -517,6 +527,7 @@ impl Config {
             index_unspendables: m.is_present("index_unspendables"),
             cors: m.value_of("cors").map(|s| s.to_string()),
             precache_scripts: m.value_of("precache_scripts").map(|s| s.to_string()),
+            serve_during_mempool_sync: m.is_present("serve_during_mempool_sync"),
             db_block_cache_mb: value_t_or_exit!(m, "db_block_cache_mb", usize),
             db_parallelism: value_t_or_exit!(m, "db_parallelism", usize),
             db_write_buffer_size_mb: value_t_or_exit!(m, "db_write_buffer_size_mb", usize),

--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -41,6 +41,10 @@ pub struct Mempool {
     edges: HashMap<OutPoint, (Txid, u32)>,          // OutPoint -> (spending_txid, spending_vin)
     recent: ArrayDeque<TxOverview, RECENT_TXS_SIZE, Wrapping>, // The N most recent txs to enter the mempool
     backlog_stats: (BacklogStats, Instant),
+    // Whether the initial sync with bitcoind's mempool has completed at least once.
+    // Until then, mempool-derived data (unconfirmed history, outspends, backlog stats)
+    // is incomplete; exposed via /health/ready for readiness checks.
+    synced: bool,
 
     // monitoring
     latency: HistogramVec, // mempool requests latency
@@ -81,6 +85,7 @@ impl Mempool {
                 BacklogStats::default(),
                 Instant::now() - Duration::from_secs(BACKLOG_STATS_TTL),
             ),
+            synced: false,
             latency: metrics.histogram_vec(
                 HistogramOpts::new("mempool_latency", "Mempool requests latency (in seconds)"),
                 &["part"],
@@ -103,6 +108,10 @@ impl Mempool {
 
     pub fn network(&self) -> Network {
         self.config.network_type
+    }
+
+    pub fn is_synced(&self) -> bool {
+        self.synced
     }
 
     pub fn lookup_txn(&self, txid: &Txid) -> Option<Transaction> {
@@ -576,6 +585,7 @@ impl Mempool {
             .set(new_txids.len() as f64);
 
         if new_txids.is_empty() {
+            Self::mark_synced(mempool);
             return Ok(true);
         }
 
@@ -648,8 +658,16 @@ impl Mempool {
         }
 
         trace!("mempool is synced");
+        Self::mark_synced(mempool);
 
         Ok(true)
+    }
+
+    fn mark_synced(mempool: &Arc<RwLock<Mempool>>) {
+        if !mempool.read().unwrap().synced {
+            mempool.write().unwrap().synced = true;
+            info!("initial mempool sync complete");
+        }
     }
 }
 

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -69,6 +69,10 @@ impl Query {
         self.mempool.read().unwrap()
     }
 
+    pub fn mempool_synced(&self) -> bool {
+        self.mempool.read().unwrap().is_synced()
+    }
+
     #[trace]
     pub fn broadcast_raw(&self, txhex: &str) -> Result<Txid> {
         let txid = self.daemon.broadcast_raw(txhex)?;

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -697,6 +697,28 @@ fn handle_request(
         path.get(3),
         path.get(4),
     ) {
+        (&Method::GET, Some(&"health"), Some(&"ready"), None, None, None) => {
+            // The chain index is always synced by the time the server is listening; the
+            // mempool may still be performing its initial sync when started with
+            // --serve-during-mempool-sync. 503 keeps not-fully-synced instances out of
+            // load balancer rotation while still being reachable for diagnostics.
+            let mempool_synced = query.mempool_synced();
+            let status = if mempool_synced {
+                StatusCode::OK
+            } else {
+                StatusCode::SERVICE_UNAVAILABLE
+            };
+            Ok(Response::builder()
+                .status(status)
+                .header("Content-Type", "application/json")
+                .header("Cache-Control", "no-cache")
+                .body(Full::new(Bytes::from(format!(
+                    "{{\"chain_synced\":true,\"mempool_synced\":{}}}",
+                    mempool_synced
+                ))))
+                .unwrap())
+        }
+
         (&Method::GET, Some(&"blocks"), Some(&"tip"), Some(&"hash"), None, None) => http_message(
             StatusCode::OK,
             query.chain().best_hash().to_string(),

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -108,6 +108,7 @@ impl TestRunner {
             index_unspendables: false,
             cors: None,
             precache_scripts: None,
+            serve_during_mempool_sync: false,
             utxos_limit: 100,
             electrum_txs_limit: 100,
             electrum_banner: "".into(),


### PR DESCRIPTION
## Problem

After a restart, electrs refuses to listen on any port until it has serially completed the popular-scripts precache **and** a full initial mempool sync over JSONRPC. With a congested mainnet mempool this keeps an instance unreachable for 15-30+ minutes, even though the chain index is fully usable within seconds of opening the database.

Measured on a production mainnet instance (2026-06-11): **~17 minutes from process start to first accepted connection**, of which DB open + chain catch-up was 17s, precache 17s, and the initial mempool sync 15.2 min (including a bitcoind `disconnected while receiving` mid-load).

Recent perf work (e.g. running parallel RPC requests on the `rpc_threads` pool) makes the mempool sync faster, but doesn't change the ordering: however quick the sync gets, the servers still won't accept a single connection until it finishes, and the precache still runs serially before it. This PR removes the waiting and adds the health signal needed to do that safely.

## Changes

1. **Precache runs in a background thread.** It is pure cache warming and never affects correctness; the scripthash file is still read upfront so a bad path fails fast. In practice it gets a head start while the mempool syncs, so it's typically warm before traffic arrives.
2. **New flag `--serve-during-mempool-sync` (default off → zero behavior change).** When enabled, the REST/Electrum servers start before the initial mempool sync. Chain/block/tx/address queries are fully correct during the sync; mempool-derived data (unconfirmed history entries, outspends, `/mempool*`, Electrum subscription status) is incomplete until the first full sync. Fee estimates are unaffected (they come from bitcoind's `estimatesmartfee`).
3. **New endpoint `GET /health/ready`** → `{"chain_synced":true,"mempool_synced":bool}`, HTTP 200 once the initial mempool sync has completed, 503 before. `Cache-Control: no-cache`.

## Operational coupling (important)

Enabling `--serve-during-mempool-sync` while health checks are plain TCP checks would route traffic to instances with an incomplete mempool view. Rollout order per deployment:

1. Ship this version (flag off), no-op apart from the background precache.
2. Switch readiness/health checks from TCP to `GET /health/ready` on the HTTP port.
3. Add `--serve-during-mempool-sync` to the start arguments.

End state: the process accepts connections ~30s after start, health checks still flip to healthy only when the mempool is synced (same externally visible behavior as today), and operators gain visibility into which startup phase an instance is in instead of staring at a closed port. Deployments fronted by redundant instances can later opt to gate health on `chain_synced` only and accept a briefly stale mempool to cut restart downtime to ~1 minute.

## Notes for reviewers

- `Mempool::update` already returns `Ok(true)` only after a full consistent snapshot; the `synced` flag is set at both success returns and is monotonic.
- During the initial sync the final `add()` holds the mempool write lock for the bulk apply; early-served requests touching the mempool can briefly block. Traffic is unaffected when health checks gate on `/health/ready`.
- Tested: `cargo check --all-targets` (both feature sets), `cargo test --lib`, CI integration suites green.
