### PR TITLE
fix(electrum): stop logging full response payload on client disconnect

### DIFF
--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -553,7 +553,7 @@ impl Connection {
             let line = value.to_string() + "\n";
             self.stream
                 .write_all(line.as_bytes())
-                .chain_err(|| format!("failed to send {}", value))?;
+                .chain_err(|| format!("failed to send response ({} bytes)", line.len()))?;
         }
         Ok(())
     }
@@ -676,11 +676,16 @@ impl Connection {
         let sender = self.sender.clone();
         let child = spawn_thread("reader", || Connection::reader_thread(reader, sender));
         if let Err(e) = self.handle_replies(receiver) {
-            error!(
-                "[{}] connection handling failed: {}",
-                self.addr,
-                e.display_chain().to_string()
-            );
+            if is_disconnect(&e) {
+                // client went away mid-exchange (broken pipe / reset) — not actionable
+                debug!("[{}] connection closed by client: {}", self.addr, e);
+            } else {
+                error!(
+                    "[{}] connection handling failed: {}",
+                    self.addr,
+                    e.display_chain().to_string()
+                );
+            }
         }
         self.stats.clients.dec();
         self.stats
@@ -695,6 +700,25 @@ impl Connection {
             error!("[{}] receiver failed: {}", self.addr, err);
         }
     }
+}
+
+/// True if the error chain is rooted in a client disconnect (broken pipe /
+/// connection reset / aborted), which is expected and shouldn't be logged as ERROR.
+fn is_disconnect(err: &Error) -> bool {
+    use std::io::ErrorKind::*;
+    let mut cause: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = cause {
+        if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+            if matches!(
+                io_err.kind(),
+                BrokenPipe | ConnectionReset | ConnectionAborted | UnexpectedEof
+            ) {
+                return true;
+            }
+        }
+        cause = e.source();
+    }
+    false
 }
 
 #[trace]


### PR DESCRIPTION
## Problem

A client that disconnects mid-response (broken pipe / connection reset) caused the **entire JSON-RPC reply** to be logged at `ERROR`. For large replies — e.g. a `blockchain.scripthash.get_history` result for a very popular address — this dumped a multi-megabyte line to stderr, which Cloud Logging then split across many ERROR entries.

Root cause chain in `src/electrum/server.rs`:

1. `send_values()` built its error context with `format!("failed to send {}", value)`, embedding the *entire* reply `Value` into the error string.
2. That error propagated up to `run()` and was logged via `error!(... e.display_chain() ...)`.
3. `stderrlog` writes to stderr, which GKE/Cloud Logging tags as `ERROR` severity by default.

## Fix

- Truncate the send-failure context to a byte count instead of the full payload:
  ```rust
  .chain_err(|| format!("failed to send response ({} bytes)", line.len()))?;
  ```
- Add an `is_disconnect()` helper that walks the error `source()` chain for `BrokenPipe | ConnectionReset | ConnectionAborted | UnexpectedEof`.
- In `run()`, route client disconnects to `debug!` (expected, not actionable) while genuine failures still log at `error!`.

## Result

No more multi-megabyte ERROR spam. A client disconnecting mid-response now produces a single concise `debug!` line; real write/protocol failures remain at `error!` without the payload.
