### PR TITLE
feat(electrum): add blockchain.scripthash.get_mempool

### DIFF
--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -400,6 +400,27 @@ impl Connection {
             .collect::<Vec<_>>()))
     }
 
+    fn blockchain_scripthash_get_mempool(&self, params: &[Value]) -> Result<Value> {
+        let script_hash = hash_from_value(params.get(0))?;
+        // ask for one extra more than the limit and fail if it exists, to avoid silently truncating
+        let mempool_txids = self
+            .query
+            .mempool()
+            .history_txids(&script_hash[..], self.txs_limit + 1);
+        ensure!(mempool_txids.len() <= self.txs_limit, ErrorKind::TooPopular);
+
+        Ok(json!(mempool_txids
+            .into_iter()
+            .map(|txid| {
+                let fee = self.query.get_mempool_tx_fee(&txid);
+                let has_unconfirmed_parents = self.query.has_unconfirmed_parents(&txid);
+                // per the Electrum protocol: 0 if all inputs are confirmed, -1 otherwise
+                let height = if has_unconfirmed_parents { -1 } else { 0 };
+                GetHistoryResult { txid, height, fee }
+            })
+            .collect::<Vec<_>>()))
+    }
+
     fn blockchain_scripthash_listunspent(&self, params: &[Value]) -> Result<Value> {
         let script_hash = hash_from_value(params.get(0))?;
         let utxos = self.query.utxo(&script_hash[..])?;
@@ -517,6 +538,7 @@ impl Connection {
             #[cfg(not(feature = "liquid"))]
             "blockchain.scripthash.get_balance" => self.blockchain_scripthash_get_balance(&params),
             "blockchain.scripthash.get_history" => self.blockchain_scripthash_get_history(&params),
+            "blockchain.scripthash.get_mempool" => self.blockchain_scripthash_get_mempool(&params),
             "blockchain.scripthash.listunspent" => self.blockchain_scripthash_listunspent(&params),
             "blockchain.scripthash.subscribe" => self.blockchain_scripthash_subscribe(&params),
             "blockchain.scripthash.unsubscribe" => self.blockchain_scripthash_unsubscribe(&params),

--- a/tests/electrum.rs
+++ b/tests/electrum.rs
@@ -264,6 +264,59 @@ fn test_electrum_jsonrpc_errors() {
     assert_eq!(s, expected);
 }
 
+/// Test blockchain.scripthash.get_mempool returns only the unconfirmed history of a scripthash
+#[cfg_attr(not(feature = "liquid"), test)]
+#[cfg_attr(feature = "liquid", allow(dead_code))]
+fn test_electrum_scripthash_get_mempool() -> Result<()> {
+    use bitcoin::hashes::{sha256, Hash};
+    use bitcoin::hex::DisplayHex;
+
+    let (_electrum_server, electrum_addr, mut tester) = common::init_electrum_tester()?;
+
+    let addr = tester.newaddress()?;
+
+    // Electrum protocol script hash: single SHA256 of the scriptPubKey, in reversed byte order
+    let mut hash = sha256::Hash::hash(addr.script_pubkey().as_bytes()).to_byte_array();
+    hash.reverse();
+    let scripthash = hash.to_lower_hex_string();
+
+    let request = |id: u32| {
+        format!(
+            "{{\"jsonrpc\": \"2.0\", \"method\": \"blockchain.scripthash.get_mempool\", \"params\": [\"{}\"], \"id\": {}}}",
+            scripthash, id
+        )
+    };
+
+    let mut stream = TcpStream::connect(electrum_addr).unwrap();
+
+    // no mempool history yet
+    let s = write_and_read(&mut stream, &request(1));
+    assert_eq!(s, "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":[]}");
+
+    // an unconfirmed tx funding the address shows up (tester.send syncs the mempool index)
+    let txid = tester.send(&addr, "0.1 BTC".parse().unwrap())?;
+
+    let s = write_and_read(&mut stream, &request(2));
+    let v: electrumd::jsonrpc::serde_json::Value =
+        electrumd::jsonrpc::serde_json::from_str(&s).unwrap();
+    let entries = v["result"].as_array().expect("result array");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0]["tx_hash"].as_str(),
+        Some(txid.to_string().as_str())
+    );
+    // height 0: all inputs confirmed (no unconfirmed parents)
+    assert_eq!(entries[0]["height"].as_i64(), Some(0));
+    assert!(entries[0]["fee"].as_u64().is_some());
+
+    // once confirmed, it no longer appears in the mempool result
+    tester.mine()?;
+    let s = write_and_read(&mut stream, &request(3));
+    assert_eq!(s, "{\"id\":3,\"jsonrpc\":\"2.0\",\"result\":[]}");
+
+    Ok(())
+}
+
 fn write_and_read(stream: &mut TcpStream, write: &str) -> String {
     stream.write_all(write.as_bytes()).unwrap();
     stream.write(b"\n").unwrap();


### PR DESCRIPTION
## Summary

Implements `blockchain.scripthash.get_mempool`, part of the [Electrum protocol](https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-mempool) (a method that has existed since 1.1; electrs advertises 1.4). Previously a client calling this method received an unknown-method error (EOF), which is confusing given the advertised protocol version.

The new handler returns the **unconfirmed** history of a script hash as a list of `{tx_hash, height, fee}`, where:
- `height` is `0` when all of the transaction's inputs are confirmed, and
- `height` is `-1` when the transaction has unconfirmed parents,

per the spec. It performs a mempool-only lookup and enforces the same `txs_limit` / `TooPopular` guard already used by `get_history`, reusing the existing `GetHistoryResult` serialization so `fee` is included.

On ordering: at protocol 1.4 the result order is undefined, so this returns results in mempool order. Protocol 1.6 tightens this to a canonical `(-height, tx_hash)` order; that's tracked with the broader 1.6 work in #172.

## Test plan

Adds `test_electrum_scripthash_get_mempool` (`tests/electrum.rs`), which verifies:
- an empty result for a script hash with no mempool history,
- a single entry with `height: 0` and a present `fee` after an unconfirmed funding tx, and
- the entry disappearing from the result once the tx is confirmed.

Closes #120