### PR TITLE
docs: refresh Electrum protocol links and prune stale TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Additional options with the `liquid` feature:
 - `--parent-network <network>` - the parent network this chain is pegged to.
 
 Additional options with the `electrum-discovery` feature:
-- `--electrum-hosts <json>` - a json map of the public hosts where the electrum server is reachable, in the [`server.features` format](https://electrumx.readthedocs.io/en/latest/protocol-methods.html#server.features).
+- `--electrum-hosts <json>` - a json map of the public hosts where the electrum server is reachable, in the [`server.features` format](https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#server-features).
 - `--electrum-announce` - announce the electrum server on the electrum p2p server discovery network.
 
 See `$ cargo run --release --bin electrs -- --help` for the full list of options.

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,10 @@
 # Electrum
 
 * Snapshot DB after successful indexing - and run queries on the latest snapshot
-* Update height to -1 for txns with any [unconfirmed input](https://electrumx.readthedocs.io/en/latest/protocol-basics.html#status)
 
 # Rust
 
 * Use [bytes](https://carllerche.github.io/bytes/bytes/index.html) instead of `Vec<u8>` when possible
-* Use generators instead of vectors
 * Use proper HTTP parser for JSONRPC replies over persistent connection
 
 # Performance

--- a/src/config.rs
+++ b/src/config.rs
@@ -308,7 +308,7 @@ impl Config {
         let args = args.arg(
                 Arg::with_name("electrum_public_hosts")
                     .long("electrum-public-hosts")
-                    .help("A dictionary of hosts where the Electrum server can be reached at. Required to enable server discovery. See https://electrumx.readthedocs.io/en/latest/protocol-methods.html#server-features")
+                    .help("A dictionary of hosts where the Electrum server can be reached at. Required to enable server discovery. See https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#server-features")
                     .takes_value(true)
             ).arg(
                 Arg::with_name("electrum_announce")


### PR DESCRIPTION
## Summary

The ElectrumX docs at `electrumx.readthedocs.io` are effectively frozen around protocol 1.4.2. The maintained, canonical Electrum protocol spec now lives at [spesmilo/electrum-protocol](https://github.com/spesmilo/electrum-protocol/) (rendered at [electrum-protocol.readthedocs.io](https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html)).

### Doc-link refresh
Point the remaining references at the maintained docs:
- `README.md` — `--electrum-hosts` / `server.features` format link
- `src/config.rs` — `--electrum-public-hosts` CLI help text

The `#server-features` anchor was verified to resolve on the new docs.

### Prune stale TODO.md items
- **"Update height to -1 for txns with any unconfirmed input"** — already implemented by `get_electrum_height` (`src/electrum/mod.rs`), wired into `get_history`/`get_mempool`/status via `has_unconfirmed_parents`. 
- **"Use generators instead of vectors"** — obsolete; the codebase uses iterators throughout.

Remaining TODO items (DB snapshot for queries, `bytes` vs `Vec<u8>`, proper HTTP parser for JSONRPC replies, RocksDB tuning) are left as-is — they're still open.

Docs/help-text only; no behavior change.

Thanks to @SomberNight for [pointing out](https://github.com/Blockstream/electrs/issues/120#issuecomment-4729947532) that the up-to-date docs live at spesmilo/electrum-protocol.