### PR TITLE
chore(db): clarify full-compaction sentinel logging

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -283,15 +283,24 @@ impl Indexer {
     fn start_auto_compactions(&self, db: &DB) {
         let key = b"F".to_vec();
         if db.get(&key).is_none() {
-            info!("full-compaction sentinel 'F' not found — running one-time full compaction");
+            info!(
+                "full-compaction sentinel 'F' not found in {:?} — running one-time full compaction",
+                db
+            );
             db.full_compaction();
-            info!("full compaction finished — tightening triggers to steady-state values");
+            info!(
+                "full compaction finished for {:?} — tightening triggers to steady-state values",
+                db
+            );
             db.apply_steady_state_triggers();
             db.put_sync(&key, b"");
             assert!(db.get(&key).is_some());
-            info!("full-compaction sentinel 'F' set");
+            info!("full-compaction sentinel 'F' set in {:?}", db);
         } else {
-            info!("full-compaction sentinel 'F' found — skipping full compaction");
+            trace!(
+                "full-compaction sentinel 'F' found in {:?} — skipping full compaction",
+                db
+            );
         }
         db.enable_auto_compaction();
     }


### PR DESCRIPTION
## Summary

  Improve RocksDB full-compaction sentinel logging:

  - include the database identity in initial-sync compaction messages
  - move the routine `F`-sentinel-found message from `INFO` to `TRACE`

  ## Motivation

  Each index update checks the full-compaction sentinel for `txstore`, `history`, and
  `cache`. Once initial sync has completed, this produced three `INFO` messages for
  every new block.

  The initial-sync messages also did not identify which database was being processed,
  making the sequential compaction of the three databases look like conflicting
  sentinel or trigger transitions.

  ## Behavior

  State-changing initial-sync events remain at `INFO`:

  - sentinel missing
  - full compaction completed
  - triggers tightened
  - sentinel set

  The steady-state “sentinel found, skipping compaction” path is now logged at
  `TRACE`.

  This is a logging-only change. Compaction, trigger, and sentinel behavior is
  unchanged.