### PR TITLE
Register error-chain cfg for rustc checking.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 edition = "2018"
 default-run = "electrs"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(has_error_description_deprecated)"] }
+
 [features]
 liquid = ["elements"]
 electrum-discovery = ["electrum-client"]


### PR DESCRIPTION
## Summary

Register `has_error_description_deprecated` as a known Rust cfg.

`error-chain 0.12.4` emits this cfg while expanding its macro in electrs. Recent Rust toolchains therefore report it as unexpected, even though it originates in
the dependency.

This narrowly registers that cfg instead of disabling the `unexpected_cfgs` lint. There are no runtime behavior changes.

## Testing

- `cargo check --locked`
- `cargo check --features liquid --locked`

Both builds pass and no longer emit the `has_error_description_deprecated` warning.