### PR TITLE
Add TooManyUtxos error kind for utxos-limit failures

### DIFF
--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -106,7 +106,7 @@ impl JsonRpcV2Error {
 fn jsonrpc_code(e: &Error) -> JsonRpcV2Error {
     match e.kind() {
         ErrorKind::InvalidParams(_) => JsonRpcV2Error::InvalidParams,
-        ErrorKind::TooPopular => JsonRpcV2Error::BadRequest,
+        ErrorKind::TooPopular | ErrorKind::TooManyUtxos => JsonRpcV2Error::BadRequest,
         ErrorKind::RpcError(..) => JsonRpcV2Error::DaemonError,
         _ => JsonRpcV2Error::InternalError,
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,11 @@ error_chain! {
             display("Too many history entries")
         }
 
+        TooManyUtxos {
+            description("Too many unspent outputs")
+            display("Too many unspent outputs")
+        }
+
         InvalidParams(msg: String) {
             description("Invalid RPC params")
             display("{}", msg)

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -872,7 +872,7 @@ impl ChainQuery {
 
             // abort if the utxo set size excedees the limit at any point in time
             if utxos.len() > limit {
-                bail!(ErrorKind::TooPopular)
+                bail!(ErrorKind::TooManyUtxos)
             }
         }
 


### PR DESCRIPTION
Fixes #242.

`ErrorKind::TooPopular` ("Too many history entries") was raised from two unrelated checks: the Electrum history limit (`--electrum-txs-limit`, `src/electrum/server.rs`) and the UTXO set limit (`--utxos-limit`, `utxo_delta` in `src/new_index/schema.rs`). For the UTXO check the message names the wrong limit — it fires when the UTXO set exceeds `--utxos-limit` during history replay, regardless of history entry count. On deployments where `--electrum-txs-limit` is raised but `--utxos-limit` is left at default, an address can serve its full history while `GET /address/:addr/utxo` and `blockchain.scripthash.listunspent` fail with a message blaming history size. The REST layer returns the display string verbatim as the HTTP 400 body, so the misleading message is customer-visible.

Changes:
- Add a distinct `TooManyUtxos` error kind ("Too many unspent outputs") in `src/errors.rs`
- Raise it from `utxo_delta` in `src/new_index/schema.rs`, leaving `TooPopular` for the two Electrum history checks
- Map `TooManyUtxos` to the same Electrum JSON-RPC `BadRequest` (code 1) as `TooPopular` in `src/electrum/server.rs`

Client-visible change: the HTTP 400 body / Electrum error message for over-limit UTXO queries becomes "Too many unspent outputs" instead of "Too many history entries". The Electrum error code is unchanged (BadRequest = 1); only the message text differs.

Verified with `cargo check` and `cargo check --features liquid` (the one unused-import warning in the liquid build is pre-existing).
