### PR TITLE
test(config): use Liquid network in startup tests

### DIFF
--- a/tests/config.rs
+++ b/tests/config.rs
@@ -6,17 +6,22 @@ fn run_electrs(temp_dir: &Path, extra_args: &[&str]) -> Output {
     let monitoring_listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let monitoring_addr = monitoring_listener.local_addr().unwrap().to_string();
 
-    Command::new(env!("CARGO_BIN_EXE_electrs"))
-        .args([
-            "--db-dir",
-            temp_dir.join("db").to_str().unwrap(),
-            "--daemon-dir",
-            temp_dir.to_str().unwrap(),
-            "--daemon-rpc-addr",
-            "127.0.0.1:1",
-            "--monitoring-addr",
-            monitoring_addr.as_str(),
-        ])
+    let mut command = Command::new(env!("CARGO_BIN_EXE_electrs"));
+    command.args([
+        "--db-dir",
+        temp_dir.join("db").to_str().unwrap(),
+        "--daemon-dir",
+        temp_dir.to_str().unwrap(),
+        "--daemon-rpc-addr",
+        "127.0.0.1:1",
+        "--monitoring-addr",
+        monitoring_addr.as_str(),
+    ]);
+
+    #[cfg(feature = "liquid")]
+    command.args(["--network", "liquidregtest"]);
+
+    command
         .args(extra_args)
         .output()
         .expect("failed to run electrs")
@@ -60,9 +65,12 @@ fn startup_debug_log_identifies_cookie_file() {
     let temp_dir = tempfile::tempdir().unwrap();
     let output = run_electrs(temp_dir.path(), &["-v"]);
     let stderr = String::from_utf8(output.stderr).unwrap();
+    let daemon_dir = temp_dir.path().to_path_buf();
+    #[cfg(feature = "liquid")]
+    let daemon_dir = daemon_dir.join("liquidregtest");
     let expected = format!(
         "daemon authentication: CookieFile({:?})",
-        temp_dir.path().join(".cookie")
+        daemon_dir.join(".cookie")
     );
 
     assert!(!output.status.success(), "electrs unexpectedly succeeded");


### PR DESCRIPTION
## Summary

Make the startup authentication logging tests valid in Liquid builds.

The tests previously relied on the default `mainnet` network. With `--features liquid`, that network name is unsupported, so electrs exited during configuration parsing before emitting the authentication log messages the tests assert.

- pass `--network liquidregtest` when the test binary is built with the `liquid` feature
- account for the derived `liquidregtest` daemon subdirectory in the cookie-file assertion
- preserve the existing Bitcoin test behavior

This fixes the `test-liquid` failures first introduced with #252 and subsequently observed on #254.

## Tests

- `cargo test --test config`
- `cargo test --test config --features liquid`